### PR TITLE
Document spec layer as public API with BC promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Until 1.0.0 the public API may change between minor versions.
 
+## [Unreleased]
+
+### Changed
+
+- **Spec layer (`Temporal\Spec\`) reframed as a public API layer, not internal.** The 0.1.0 release notes described it as "considered internal"; that was a misframing. The layer is PSR-4 public and will be covered by the Backwards Compatibility Promise on the same terms as the porcelain layer starting at 1.0.0.
+- README now has a **Versioning and backwards compatibility** section that spells out the SemVer contract for each layer, the `toSpec()`/`fromSpec()` round-trip guarantee, and the `Temporal\Spec\Internal\` exclusion — resolving the "formal BC policy for the seam" note from 0.1.0.
+
 ## [0.1.0] - 2026-04-19
 
 Initial public release.
@@ -38,4 +45,5 @@ The porcelain layer adapts TC39 semantics to PHP-native conventions rather than 
 - The `Temporal\Spec\` namespace is public PSR-4 but documented as internal; a formal BC policy for the seam will land before 1.0.0.
 - Mutation testing currently reports ~72% MSI; see [issue #2](https://github.com/MidnightDesign/temporal-php/issues/2).
 
+[Unreleased]: https://github.com/MidnightDesign/temporal-php/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/MidnightDesign/temporal-php/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library has two API tiers:
 | **Porcelain** | `Temporal\` | PHP-native API with strict types, backed enums, and named arguments |
 | **Spec** | `Temporal\Spec\` | TC39-faithful implementation, validated by 6600+ test262 scripts |
 
-Use the porcelain layer for application code. The spec layer exists to pass the TC39 conformance suite and is considered internal.
+Most application code should use the porcelain layer. The spec layer is a fully supported alternative when you need TC39-faithful semantics — for example, producing output that matches JavaScript Temporal byte-for-byte. Both layers are covered by the [Backwards Compatibility Promise](#versioning-and-backwards-compatibility).
 
 ### Deliberate deviations from TC39
 
@@ -421,6 +421,21 @@ Every porcelain class has `toSpec()` and `fromSpec()` for dropping to the TC39-f
 $specDate = $date->toSpec();            // Temporal\Spec\PlainDate
 $date     = PlainDate::fromSpec($spec); // back to porcelain
 ```
+
+---
+
+## Versioning and backwards compatibility
+
+This project follows [Semantic Versioning](https://semver.org). Until 1.0.0 the public API may change between minor versions.
+
+From 1.0.0 onward, both API layers are supported under the same contract:
+
+- **Porcelain (`Temporal\`)** — public methods, property names and types, enum cases, and constructor parameters are stable within a major version.
+- **Spec (`Temporal\Spec\`)** — same contract as porcelain. This layer tracks the TC39 Temporal specification; if an upstream Stage 4 change alters observable semantics, that change ships only in a major version of this library.
+- **Seam** — for every porcelain class, `X::fromSpec($x->toSpec())` equals `$x` within a major version. You can move values between layers without lossy conversion.
+- **Internal (`Temporal\Spec\Internal\`)** — genuine implementation detail (calendar bridges, serde, arithmetic helpers). May change at any time without a major version bump. Do not import from it.
+
+Bug fixes that correct incorrect output are not breaking changes, even when an observed value changes. Deprecations are announced in the changelog at least one minor version before removal and marked with `@deprecated`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Reframe `Temporal\Spec\` as a fully supported public API, not "internal". The 0.1.0 wording in README and CHANGELOG was a misframing.
- Add a **Versioning and backwards compatibility** section to README covering both layers, the `toSpec()`/`fromSpec()` seam guarantee, and the `Temporal\Spec\Internal\` exclusion.
- Resolves the "formal BC policy for the seam will land before 1.0.0" note from 0.1.0.

The 0.1.0 CHANGELOG entry itself is left historical (released); the clarification lives under `[Unreleased]`.

## Test plan

- [ ] Rendered README looks correct on GitHub (anchor link `#versioning-and-backwards-compatibility` resolves)
- [ ] CHANGELOG `[Unreleased]` link diff resolves on GitHub

## Transparency

This PR was drafted with Claude Code. The framing decision (Spec layer is public, not internal) came from the maintainer; the prose and structure are AI-generated.