### PR TITLE
Mago-driven cleanup: lint autofixes, preg_match pre-inits, redundant-condition drops

### DIFF
--- a/mago.toml
+++ b/mago.toml
@@ -14,6 +14,9 @@ level = "error"
 [linter.rules.literal-named-argument]
 level = "error"
 
+[linter.rules.prefer-early-continue]
+level = "error"
+
 # PlainDateTime/ZonedDateTime test suites require 100+ test methods because each
 # virtual property, method, and option path per the TC39 spec must be covered.
 # ZonedDateTime is inherently the most complex class per the spec (29 properties,

--- a/src/Spec/Duration.php
+++ b/src/Spec/Duration.php
@@ -3313,7 +3313,7 @@ final class Duration implements Stringable
         // Convert to the target largest unit using float division, then distribute downward.
         // This matches JS's approach of computing the balance via float64 arithmetic.
         $floatMax = (float) PHP_INT_MAX;
-        $toIntSafe = static fn (float $v): int|float => abs($v) < $floatMax ? (int) $v : $v;
+        $toIntSafe = static fn(float $v): int|float => abs($v) < $floatMax ? (int) $v : $v;
 
         $days = 0;
         $ns = $totalAbsNs;

--- a/src/Spec/Duration.php
+++ b/src/Spec/Duration.php
@@ -854,6 +854,7 @@ final class Duration implements Stringable
                 if ($unit === 'days' && $rtIsZDT && $parsedRt['_localTimeSec'] !== 0) {
                     // Check if the timezone is IANA (not UTC/fixed-offset).
                     $tzBracket = null;
+                    $_m = null;
                     if (preg_match('/\[([^\]=]+)\]\s*$/', $rtRaw, $_m) === 1) {
                         $tzBracket = $_m[1];
                     }
@@ -1040,6 +1041,7 @@ final class Duration implements Stringable
             throw new InvalidArgumentException('relativeTo string must not have fractional hours or minutes.');
         }
         // Validate calendar annotation.
+        $calMatch = null;
         if (preg_match('/\[u-ca=([^\]]+)\]/', $s, $calMatch) === 1) {
             if (!CalendarFactory::isKnownCalendar($calMatch[1])) {
                 throw new InvalidArgumentException("Unknown calendar \"{$calMatch[1]}\".");
@@ -1067,6 +1069,7 @@ final class Duration implements Stringable
             }
             // Numeric offset: validate that the offset format is ±HH:MM[:SS[.frac]] followed by
             // end-of-string, '[', or whitespace (not extra digits).  Invalid formats (e.g. +00:0000) must throw.
+            $offMatch = null;
             if (
                 preg_match(
                     '/T\d{2}:?\d{2}(?::?\d{2}(?:\.\d+)?)?([+\-]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)(?:\[|$)/i',
@@ -1081,6 +1084,7 @@ final class Duration implements Stringable
         }
 
         // Validate the timezone bracket annotation.
+        $bracketMatch = null;
         if (preg_match('/\[([^\]]+)\]/', $s, $bracketMatch) === 1 && !str_starts_with($bracketMatch[1], 'u-ca=')) {
             $bracket = $bracketMatch[1];
             // Sub-minute bracket offset (has seconds component): invalid.
@@ -1091,13 +1095,16 @@ final class Duration implements Stringable
             }
             // Bracket is a numeric UTC offset (±HH:MM or ±HHMM): must match the inline offset
             // UNLESS the inline offset is Z (UTC instant — any timezone bracket is allowed).
+            $bOff = null;
             if (preg_match('/^([+\-])(\d{2}):?(\d{2})$/', $bracket, $bOff) === 1) {
                 $bMin = ((int) $bOff[2] * 60) + (int) $bOff[3];
                 $bMin = $bOff[1] === '-' ? -$bMin : $bMin;
+                $iOff = null;
                 if (preg_match('/T\d{2}:?\d{2}(?::?\d{2})?([+\-]\d{2}:?\d{2}|Z)/i', $s, $iOff) === 1) {
                     if ($iOff[1] === 'Z' || $iOff[1] === 'z') {
                         // Z inline offset: any bracket timezone is allowed (no matching required).
                     } else {
+                        $iOffParts = null;
                         preg_match('/^([+\-])(\d{2}):?(\d{2})/', $iOff[1], $iOffParts);
                         /**
                          * @var array{non-falsy-string, '+'|'-', non-falsy-string, non-falsy-string} $iOffParts
@@ -1112,8 +1119,10 @@ final class Duration implements Stringable
                     }
                 }
             } elseif (strtoupper($bracket) === 'UTC') {
+                $iOff = null;
                 if (preg_match('/T\d{2}:?\d{2}(?::?\d{2})?([+\-]\d{2}:?\d{2}|Z)/i', $s, $iOff) === 1) {
                     if ($iOff[1] !== 'Z' && $iOff[1] !== 'z') {
+                        $iOffParts = null;
                         preg_match('/^([+\-])(\d{2}):?(\d{2})/', $iOff[1], $iOffParts);
                         /** @var array{non-falsy-string, '+'|'-', non-falsy-string, non-falsy-string} $iOffParts */
                         $iMin = ((int) $iOffParts[2] * 60) + (int) $iOffParts[3];
@@ -1128,6 +1137,7 @@ final class Duration implements Stringable
         }
 
         // Extract date part: ±YYYY-MM-DD or YYYYMMDD.
+        $dateMatch = null;
         if (
             preg_match('/^([+\-]?\d{4,6})-(\d{2})-(\d{2})/', $s, $dateMatch) !== 1
             && preg_match('/^(\d{4})(\d{2})(\d{2})/', $s, $dateMatch) !== 1
@@ -1157,6 +1167,7 @@ final class Duration implements Stringable
             }
 
             // Extract local time (hours, minutes, seconds) and detect sub-second fraction.
+            $tm = null;
             if (preg_match('/T(\d{2}):?(\d{2})(?::?(\d{2})(\.\d+)?)?/i', $s, $tm) === 1) {
                 $localTimeSec =
                     ((int) $tm[1] * 3_600) + ((int) $tm[2] * 60) + (array_key_exists(3, $tm) ? (int) $tm[3] : 0);
@@ -1166,8 +1177,10 @@ final class Duration implements Stringable
 
             // Extract the inline UTC offset in seconds.
             $offsetSec = 0;
+            $iOff = null;
             if (preg_match('/T\d{2}:?\d{2}(?::?\d{2}(?:\.\d+)?)?([+\-]\d{2}:?\d{2}|Z)/i', $s, $iOff) === 1) {
                 if ($iOff[1] !== 'Z' && $iOff[1] !== 'z') {
+                    $offParts = null;
                     preg_match('/^([+\-])(\d{2}):?(\d{2})/', $iOff[1], $offParts);
                     /** @var array{non-falsy-string, '+'|'-', non-falsy-string, non-falsy-string} $offParts */
                     $offsetSec = ((int) $offParts[2] * 3_600) + ((int) $offParts[3] * 60);
@@ -2832,6 +2845,7 @@ final class Duration implements Stringable
                 throw new \TypeError('relativeTo offset must be a string.');
             }
             // Allow ±HH:MM or ±HH:MM:00[.000...] (seconds and sub-seconds zero).
+            $offM = null;
             if (preg_match('/^([+\-])(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?$/', $offVal, $offM) !== 1) {
                 throw new InvalidArgumentException("Invalid relativeTo offset string \"{$offVal}\".");
             }
@@ -2866,6 +2880,7 @@ final class Duration implements Stringable
             $epochSec--;
         }
         $tzId = $zdt->timeZoneId;
+        $m = null;
         if ($tzId === 'UTC') {
             $offsetSec = 0;
         } elseif (preg_match('/^([+\-])(\d{2}):(\d{2})$/', $tzId, $m) === 1) {
@@ -3370,6 +3385,7 @@ final class Duration implements Stringable
             throw new InvalidArgumentException("Invalid timeZone \"{$tz}\": minus-zero year.");
         }
         // Reject bracket annotation with a seconds component (e.g. [+23:59:60]).
+        $bm = null;
         if (preg_match('/\[([^\]]+)\]/', $tz, $bm) === 1) {
             if (preg_match('/^[+\-]\d{2}:\d{2}:\d{2}/', $bm[1]) === 1) {
                 throw new InvalidArgumentException(
@@ -3510,6 +3526,7 @@ final class Duration implements Stringable
         }
         if (is_string($rt)) {
             // Parse the string to check for IANA timezone.
+            $m = null;
             if (preg_match('/\[([^\]=]+)\]\s*$/', $rt, $m) === 1) {
                 $tzId = $m[1];
                 if ($tzId !== 'UTC' && preg_match('/^[+\-]\d{2}:\d{2}$/', $tzId) !== 1) {

--- a/src/Spec/Duration.php
+++ b/src/Spec/Duration.php
@@ -2202,10 +2202,7 @@ final class Duration implements Stringable
         }
 
         // For pure-time rounds: validate relativeTo and check overflow for non-blank durations.
-        // ($needsRelativeTo is always false here due to the throw above; suppress the tautology.)
-        /** @psalm-suppress RedundantCondition */
-        // @phpstan-ignore booleanNot.alwaysTrue
-        if (!$needsRelativeTo && $relativeToProvided && !$this->blank) {
+        if ($relativeToProvided && !$this->blank) {
             /** @var mixed $rtRaw */
             $rtRaw = $roundTo['relativeTo'] ?? null;
             if (is_string($rtRaw)) {

--- a/src/Spec/Duration.php
+++ b/src/Spec/Duration.php
@@ -109,17 +109,19 @@ final class Duration implements Stringable
                 $microseconds,
                 $nanoseconds,
             ] as $field) {
-                if (is_float($field)) {
-                    if (!is_finite($field)) {
-                        throw new InvalidArgumentException(
-                            'Duration fields must be finite; Infinity and NaN are not allowed.',
-                        );
-                    }
-                    if (fmod(num1: $field, num2: 1.0) !== 0.0) {
-                        throw new InvalidArgumentException(
-                            'Duration fields must be integer-valued; fractional values are not allowed.',
-                        );
-                    }
+                if (!is_float($field)) {
+                    continue;
+                }
+
+                if (!is_finite($field)) {
+                    throw new InvalidArgumentException(
+                        'Duration fields must be finite; Infinity and NaN are not allowed.',
+                    );
+                }
+                if (fmod(num1: $field, num2: 1.0) !== 0.0) {
+                    throw new InvalidArgumentException(
+                        'Duration fields must be integer-valued; fractional values are not allowed.',
+                    );
                 }
             }
         }
@@ -498,10 +500,12 @@ final class Duration implements Stringable
         ];
         $hasAny = false;
         foreach ($PLURAL_FIELDS as $f) {
-            if (array_key_exists($f, $fields)) {
-                $hasAny = true;
-                break;
+            if (!array_key_exists($f, $fields)) {
+                continue;
             }
+
+            $hasAny = true;
+            break;
         }
         if (!$hasAny) {
             throw new \TypeError(
@@ -622,7 +626,7 @@ final class Duration implements Stringable
 
         $subNs = ($remMs * 1_000_000) + ($remUs * 1_000) + $remNs;
         $totalSeconds = (int) $abs->seconds + $carryMs + $carryUs + $carryNs + (int) ($subNs / 1_000_000_000);
-        $subNs = $subNs % 1_000_000_000;
+        $subNs %= 1_000_000_000;
 
         // Initialize local copies of time units that may be updated by carry after rounding.
         $absMinutes = (int) $abs->minutes;
@@ -655,13 +659,13 @@ final class Duration implements Stringable
             // E.g. {h:1, min:59, sec:59, ms:900} rounds to PT2H0S; {sec:59, ms:900} stays PT60S.
             if ($carrySecond !== 0 && ($absMinutes !== 0 || $absHours !== 0)) {
                 $absMinutes += intdiv(num1: $totalSeconds, num2: 60);
-                $totalSeconds = $totalSeconds % 60;
+                $totalSeconds %= 60;
                 if ($absMinutes >= 60 && $absHours !== 0) {
                     $absHours += intdiv(num1: $absMinutes, num2: 60);
-                    $absMinutes = $absMinutes % 60;
+                    $absMinutes %= 60;
                     if ($absHours >= 24 && $absDays !== 0) {
                         $absDays += intdiv(num1: $absHours, num2: 24);
-                        $absHours = $absHours % 24;
+                        $absHours %= 24;
                     }
                 }
             }
@@ -1592,9 +1596,9 @@ final class Duration implements Stringable
         $dm = intdiv(num1: $totalFracNs, num2: 60_000_000_000);
         $rem = $totalFracNs % 60_000_000_000;
         $ds = intdiv(num1: $rem, num2: 1_000_000_000);
-        $rem = $rem % 1_000_000_000;
+        $rem %= 1_000_000_000;
         $dms = intdiv(num1: $rem, num2: 1_000_000);
-        $rem = $rem % 1_000_000;
+        $rem %= 1_000_000;
         $dus = intdiv(num1: $rem, num2: 1_000);
         $dns = $rem % 1_000;
 
@@ -1629,10 +1633,12 @@ final class Duration implements Stringable
 
         $hasAny = false;
         foreach ($PLURAL_FIELDS as $f) {
-            if (array_key_exists($f, $item)) {
-                $hasAny = true;
-                break;
+            if (!array_key_exists($f, $item)) {
+                continue;
             }
+
+            $hasAny = true;
+            break;
         }
         if (!$hasAny) {
             throw new \TypeError(
@@ -2274,15 +2280,15 @@ final class Duration implements Stringable
 
         // Balance up to get exact integers.
         $absUs += intdiv(num1: $absNs, num2: 1_000);
-        $absNs = $absNs % 1_000;
+        $absNs %= 1_000;
         $absMs += intdiv(num1: $absUs, num2: 1_000);
-        $absUs = $absUs % 1_000;
+        $absUs %= 1_000;
         $absS += intdiv(num1: $absMs, num2: 1_000);
-        $absMs = $absMs % 1_000;
+        $absMs %= 1_000;
         $absM += intdiv(num1: $absS, num2: 60);
-        $absS = $absS % 60;
+        $absS %= 60;
         $absH += intdiv(num1: $absM, num2: 60);
-        $absM = $absM % 60;
+        $absM %= 60;
 
         // Balance hours into days: DST-aware when ZDT IANA relativeTo is present.
         if ($zdtInfoRound !== null) {
@@ -2319,7 +2325,7 @@ final class Duration implements Stringable
             $absNs = $timeOnlyNs - ($absUs * 1_000);
         } else {
             $absD += intdiv(num1: $absH, num2: 24);
-            $absH = $absH % 24;
+            $absH %= 24;
         }
 
         // Compute totalNs, guarding against int64 overflow for large day counts.
@@ -2895,17 +2901,17 @@ final class Duration implements Stringable
         $ns = (int) abs((float) $d->nanoseconds);
 
         $us += intdiv(num1: $ns, num2: 1_000);
-        $ns = $ns % 1_000;
+        $ns %= 1_000;
         $ms += intdiv(num1: $us, num2: 1_000);
-        $us = $us % 1_000;
+        $us %= 1_000;
         $s += intdiv(num1: $ms, num2: 1_000);
-        $ms = $ms % 1_000;
+        $ms %= 1_000;
         $m += intdiv(num1: $s, num2: 60);
-        $s = $s % 60;
+        $s %= 60;
         $h += intdiv(num1: $m, num2: 60);
-        $m = $m % 60;
+        $m %= 60;
         $days = (int) abs((float) $d->days) + intdiv(num1: $h, num2: 24);
-        $h = $h % 24;
+        $h %= 24;
 
         $subNs =
             ($h * 3_600_000_000_000)
@@ -3295,9 +3301,7 @@ final class Duration implements Stringable
         // Convert to the target largest unit using float division, then distribute downward.
         // This matches JS's approach of computing the balance via float64 arithmetic.
         $floatMax = (float) PHP_INT_MAX;
-        $toIntSafe = static function (float $v) use ($floatMax): int|float {
-            return abs($v) < $floatMax ? (int) $v : $v;
-        };
+        $toIntSafe = static fn (float $v): int|float => abs($v) < $floatMax ? (int) $v : $v;
 
         $days = 0;
         $ns = $totalAbsNs;
@@ -4083,7 +4087,7 @@ final class Duration implements Stringable
         // remaining days stay as plain days (no weeks distribution).
         if ($luIdx === 7 || $suIdx === 7) {
             $weeks = intdiv(num1: $remainingDays, num2: 7);
-            $remainingDays = $remainingDays % 7;
+            $remainingDays %= 7;
         }
 
         // $years and $months are unsigned counters; apply sign. $weeks and $remainingDays

--- a/src/Spec/Instant.php
+++ b/src/Spec/Instant.php
@@ -1384,23 +1384,23 @@ final class Instant implements Stringable
 
         if ($luIdx >= 1) { // at least microseconds
             $us = intdiv(num1: $ns, num2: 1_000);
-            $ns = $ns - ($us * 1_000);
+            $ns -= $us * 1_000;
         }
         if ($luIdx >= 2) { // at least milliseconds
             $ms = intdiv(num1: $us, num2: 1_000);
-            $us = $us - ($ms * 1_000);
+            $us -= $ms * 1_000;
         }
         if ($luIdx >= 3) { // at least seconds
             $s = intdiv(num1: $ms, num2: 1_000);
-            $ms = $ms - ($s * 1_000);
+            $ms -= $s * 1_000;
         }
         if ($luIdx >= 4) { // at least minutes
             $min = intdiv(num1: $s, num2: 60);
-            $s = $s - ($min * 60);
+            $s -= $min * 60;
         }
         if ($luIdx >= 5) { // hours
             $h = intdiv(num1: $min, num2: 60);
-            $min = $min - ($h * 60);
+            $min -= $h * 60;
         }
 
         return new Duration(0, 0, 0, 0, $sign * $h, $sign * $min, $sign * $s, $sign * $ms, $sign * $us, $sign * $ns);

--- a/src/Spec/Instant.php
+++ b/src/Spec/Instant.php
@@ -459,6 +459,7 @@ final class Instant implements Stringable
             } else {
                 // IANA timezone: extract the timezone name from the string.
                 // For bracket annotations, extract the bracket content.
+                $bm2 = null;
                 if (preg_match('/\[([^\]]+)\]/', $tzStr, $bm2) === 1) {
                     $ianaTimeZone = $bm2[1];
                 } else {
@@ -562,6 +563,7 @@ final class Instant implements Stringable
             throw new InvalidArgumentException("Invalid timeZone \"{$tz}\": minus-zero year.");
         }
         // Reject bracket annotation with a seconds component (e.g. [+23:59:60]).
+        $bm = null;
         if (preg_match('/\[([^\]]+)\]/', $tz, $bm) === 1) {
             if (preg_match('/^[+\-]\d{2}:\d{2}:\d{2}/', $bm[1]) === 1) {
                 throw new InvalidArgumentException(
@@ -608,6 +610,7 @@ final class Instant implements Stringable
             return 0;
         }
         // Pure UTC-offset strings: ±HH:MM or ±HHMM
+        $m = null;
         if (preg_match('/^([+\-])(\d{2}):(\d{2})$/', $tz, $m) === 1) {
             $sign = $m[1] === '+' ? 1 : -1;
             return $sign * (((int) $m[2] * 3600) + ((int) $m[3] * 60));
@@ -617,12 +620,14 @@ final class Instant implements Stringable
             return $sign * (((int) $m[2] * 3600) + ((int) $m[3] * 60));
         }
         // Datetime strings: bracket annotation takes precedence.
+        $bm = null;
         if (preg_match('/\[([^\]]+)\]/', $tz, $bm) === 1) {
             /** @var non-empty-string $bracket */
             $bracket = $bm[1];
             if (strtoupper($bracket) === 'UTC') {
                 return 0;
             }
+            $om = null;
             if (preg_match('/^([+\-])(\d{2}):(\d{2})$/', $bracket, $om) === 1) {
                 $sign = $om[1] === '+' ? 1 : -1;
                 return $sign * (((int) $om[2] * 3600) + ((int) $om[3] * 60));
@@ -638,6 +643,7 @@ final class Instant implements Stringable
             }
         }
         // Datetime strings without bracket: use inline offset or Z.
+        $om = null;
         if (preg_match('/[Tt].*?(Z|([+\-])(\d{2}):(\d{2}))/i', $tz, $om) === 1) {
             if ($om[1] === 'Z' || $om[1] === 'z') {
                 return 0;
@@ -757,6 +763,7 @@ final class Instant implements Stringable
 
         if ($isDatetime) {
             // Bracket annotation takes precedence over the inline offset.
+            $bm = null;
             if (preg_match('/\[(!?[^\]]+)\]/', $tz, $bm) === 1) {
                 /** @var non-empty-string $bracket */
                 $bracket = $bm[1];
@@ -793,6 +800,7 @@ final class Instant implements Stringable
             if (preg_match('/[Zz](?:\[|$)/', $tz) === 1) {
                 return 'UTC';
             }
+            $om = null;
             if (preg_match('/([+\-]\d{2}:\d{2})(?:\[|$)/', $tz, $om) === 1) {
                 return $om[1];
             }
@@ -807,6 +815,7 @@ final class Instant implements Stringable
             return $tz;
         }
         // ±HHMM (compact form) → normalize to ±HH:MM.
+        $m = null;
         if (preg_match('/^([+\-])(\d{2})(\d{2})$/', $tz, $m) === 1) {
             return sprintf('%s%s:%s', $m[1], $m[2], $m[3]);
         }

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -894,6 +894,7 @@ final class IntlCalendarBridge implements CalendarProtocol
     private function defaultMonthCodeToMonth(string $monthCode): int
     {
         $maxMonth = $this->isCopticLike ? 13 : 12;
+        $m = null;
         if (preg_match('/^M(\d{2})$/', $monthCode, $m) !== 1) {
             throw new InvalidArgumentException(
                 "Invalid monthCode \"{$monthCode}\" for calendar \"{$this->calendarId}\".",
@@ -924,6 +925,7 @@ final class IntlCalendarBridge implements CalendarProtocol
             }
             return 6;
         }
+        $m = null;
         if (preg_match('/^M(\d{2})$/', $monthCode, $m) !== 1) {
             throw new InvalidArgumentException("Invalid monthCode \"{$monthCode}\" for hebrew calendar.");
         }
@@ -949,6 +951,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         $isLeapCode = str_ends_with($monthCode, 'L');
         $baseCode = $isLeapCode ? substr($monthCode, offset: 0, length: -1) : $monthCode;
 
+        $m = null;
         if (preg_match('/^M(\d{2})$/', $baseCode, $m) !== 1) {
             throw new InvalidArgumentException(
                 "Invalid monthCode \"{$monthCode}\" for calendar \"{$this->calendarId}\".",
@@ -1286,6 +1289,7 @@ final class IntlCalendarBridge implements CalendarProtocol
                 }
                 $this->intlCal->set(\IntlCalendar::FIELD_MONTH, 5);
             } else {
+                $m = null;
                 if (preg_match('/^M(\d{2})$/', $monthCode, $m) !== 1) {
                     throw new InvalidArgumentException("Invalid monthCode \"{$monthCode}\" for hebrew calendar.");
                 }
@@ -1303,6 +1307,7 @@ final class IntlCalendarBridge implements CalendarProtocol
             // Chinese/Dangi: MxxL → ICU month xx-1 with IS_LEAP_MONTH=1
             $isLeapCode = str_ends_with($monthCode, 'L');
             $baseCode = $isLeapCode ? substr($monthCode, offset: 0, length: -1) : $monthCode;
+            $m = null;
             if (preg_match('/^M(\d{2})$/', $baseCode, $m) !== 1) {
                 throw new InvalidArgumentException(
                     "Invalid monthCode \"{$monthCode}\" for calendar \"{$this->calendarId}\".",
@@ -1328,6 +1333,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         } else {
             // Standard calendars: M01-M12 → ICU 0-11; M13 → ICU 12 (coptic/ethiopic/ethioaa)
             $maxMonth = $this->isCopticLike ? 13 : 12;
+            $m = null;
             if (preg_match('/^M(\d{2})$/', $monthCode, $m) !== 1) {
                 throw new InvalidArgumentException(
                     "Invalid monthCode \"{$monthCode}\" for calendar \"{$this->calendarId}\".",

--- a/src/Spec/Internal/Calendar/PureHebrewCalendar.php
+++ b/src/Spec/Internal/Calendar/PureHebrewCalendar.php
@@ -230,6 +230,7 @@ final class PureHebrewCalendar implements CalendarProtocol
             return 6;
         }
 
+        $m = null;
         if (preg_match('/^M(\d{2})$/', $monthCode, $m) !== 1) {
             throw new InvalidArgumentException("Invalid monthCode \"{$monthCode}\" for hebrew calendar.");
         }

--- a/src/Spec/Internal/Calendar/PureIndianCalendar.php
+++ b/src/Spec/Internal/Calendar/PureIndianCalendar.php
@@ -238,6 +238,7 @@ final class PureIndianCalendar implements CalendarProtocol
     #[\Override]
     public function calendarToIsoFromMonthCode(int $calYear, string $monthCode, int $calDay, string $overflow): array
     {
+        $m = null;
         if (preg_match('/^M(\d{2})$/', $monthCode, $m) !== 1) {
             throw new InvalidArgumentException("Invalid monthCode \"{$monthCode}\" for calendar \"indian\".");
         }
@@ -404,6 +405,7 @@ final class PureIndianCalendar implements CalendarProtocol
     #[\Override]
     public function monthCodeToMonth(string $monthCode, int $calYear): int
     {
+        $m = null;
         if (preg_match('/^M(\d{2})$/', $monthCode, $m) !== 1) {
             throw new InvalidArgumentException("Invalid monthCode \"{$monthCode}\" for calendar \"indian\".");
         }

--- a/src/Spec/Internal/CalendarMath.php
+++ b/src/Spec/Internal/CalendarMath.php
@@ -146,6 +146,7 @@ final class CalendarMath
         }
 
         // Convert fixed-offset timezone to ICU-compatible format (GMT±HH:MM).
+        $m = null;
         if (preg_match('/^([+\-])(\d{2}):(\d{2})$/', $timeZone, $m) === 1) {
             if ($m[2] === '00' && $m[3] === '00') {
                 $timeZone = 'GMT';
@@ -489,6 +490,7 @@ final class CalendarMath
         $calHasCritical = false;
         $calendarId = null;
 
+        $matches = null;
         preg_match_all('/\[(!?)([^\]]*)\]/', $section, $matches, PREG_SET_ORDER);
 
         foreach ($matches as $match) {

--- a/src/Spec/Internal/CalendarMath.php
+++ b/src/Spec/Internal/CalendarMath.php
@@ -112,10 +112,12 @@ final class CalendarMath
         }
 
         foreach (self::COMPONENT_OPTIONS as $opt) {
-            if (($opts[$opt] ?? null) !== null) {
-                $style = $hasDateStyle ? 'dateStyle' : 'timeStyle';
-                throw new \TypeError(sprintf('toLocaleString(): %s and %s cannot be used together.', $style, $opt));
+            if (($opts[$opt] ?? null) === null) {
+                continue;
             }
+
+            $style = $hasDateStyle ? 'dateStyle' : 'timeStyle';
+            throw new \TypeError(sprintf('toLocaleString(): %s and %s cannot be used together.', $style, $opt));
         }
     }
 
@@ -257,10 +259,12 @@ final class CalendarMath
         // Check for individual component options that require a custom pattern
         $hasComponents = false;
         foreach (self::COMPONENT_OPTIONS as $opt) {
-            if (($opts[$opt] ?? null) !== null) {
-                $hasComponents = true;
-                break;
+            if (($opts[$opt] ?? null) === null) {
+                continue;
             }
+
+            $hasComponents = true;
+            break;
         }
 
         if ($hasComponents) {

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -1336,7 +1336,7 @@ final class PlainDate implements Stringable
                 $receiverIsLater,
             );
             $roundedYears = intdiv(num1: $roundedMonths, num2: 12);
-            $roundedMonths = $roundedMonths - ($roundedYears * 12);
+            $roundedMonths -= $roundedYears * 12;
             return new Duration(years: $sinceSign * $roundedYears, months: $sinceSign * $roundedMonths);
         }
         // smallestUnit=day: return years + months + rounded days.

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -1802,6 +1802,7 @@ final class PlainDate implements Stringable
         //   YYYY-MM  YYYY-MM-DD  YYYY-MM-DDTHH...  MM-DD
         // These all START with digits and contain a '-' within the first 7 chars.
         if (str_contains($cal, '[')) {
+            $m = null;
             if (preg_match('/\[!?u-ca=([^\]]+)\]/', $cal, $m) === 1) {
                 return strtolower($m[1]);
             }

--- a/src/Spec/PlainDateTime.php
+++ b/src/Spec/PlainDateTime.php
@@ -471,10 +471,12 @@ final class PlainDateTime implements Stringable
         ];
         $hasRecognized = false;
         foreach ($recognized as $key) {
-            if (array_key_exists($key, $fields)) {
-                $hasRecognized = true;
-                break;
+            if (!array_key_exists($key, $fields)) {
+                continue;
             }
+
+            $hasRecognized = true;
+            break;
         }
         if (!$hasRecognized) {
             throw new \TypeError('PlainDateTime::with() requires at least one recognized temporal property.');
@@ -874,11 +876,11 @@ final class PlainDateTime implements Stringable
         $h = intdiv(num1: $newTimeNs, num2: self::NS_PER_HOUR);
         $rem = $newTimeNs % self::NS_PER_HOUR;
         $min = intdiv(num1: $rem, num2: self::NS_PER_MINUTE);
-        $rem = $rem % self::NS_PER_MINUTE;
+        $rem %= self::NS_PER_MINUTE;
         $sec = intdiv(num1: $rem, num2: self::NS_PER_SECOND);
-        $rem = $rem % self::NS_PER_SECOND;
+        $rem %= self::NS_PER_SECOND;
         $ms = intdiv(num1: $rem, num2: self::NS_PER_MS);
-        $rem = $rem % self::NS_PER_MS;
+        $rem %= self::NS_PER_MS;
         $us = intdiv(num1: $rem, num2: self::NS_PER_US);
         $ns = $rem % self::NS_PER_US;
 
@@ -1049,9 +1051,9 @@ final class PlainDateTime implements Stringable
         $hour = intdiv(num1: $newTimeNs, num2: self::NS_PER_HOUR);
         $rem = $newTimeNs % self::NS_PER_HOUR;
         $min = intdiv(num1: $rem, num2: self::NS_PER_MINUTE);
-        $rem = $rem % self::NS_PER_MINUTE;
+        $rem %= self::NS_PER_MINUTE;
         $sec = intdiv(num1: $rem, num2: self::NS_PER_SECOND);
-        $rem = $rem % self::NS_PER_SECOND;
+        $rem %= self::NS_PER_SECOND;
 
         $subNs = $rem;
 
@@ -1955,7 +1957,7 @@ final class PlainDateTime implements Stringable
                     );
                     if ($normLargest === 'year') {
                         $roundedYears = intdiv(num1: $roundedMonths, num2: 12);
-                        $roundedMonths = $roundedMonths - ($roundedYears * 12);
+                        $roundedMonths -= $roundedYears * 12;
                         return new Duration(years: $outputSign * $roundedYears, months: $outputSign * $roundedMonths);
                     }
                     return new Duration(months: $outputSign * $roundedMonths);
@@ -2022,7 +2024,7 @@ final class PlainDateTime implements Stringable
 
             // Handle day overflow from rounding time (e.g., 23:59 rounds up to 24:00).
             $overflowDays = intdiv(num1: $absTimeNs, num2: self::NS_PER_DAY);
-            $absTimeNs = $absTimeNs % self::NS_PER_DAY;
+            $absTimeNs %= self::NS_PER_DAY;
 
             // When time overflow produces extra days, recompute the calendar diff
             // from the updated position to properly rebalance months/years.
@@ -2069,11 +2071,11 @@ final class PlainDateTime implements Stringable
             $h = intdiv(num1: $absTimeNs, num2: self::NS_PER_HOUR);
             $rem = $absTimeNs % self::NS_PER_HOUR;
             $min = intdiv(num1: $rem, num2: self::NS_PER_MINUTE);
-            $rem = $rem % self::NS_PER_MINUTE;
+            $rem %= self::NS_PER_MINUTE;
             $sec = intdiv(num1: $rem, num2: self::NS_PER_SECOND);
-            $rem = $rem % self::NS_PER_SECOND;
+            $rem %= self::NS_PER_SECOND;
             $ms = intdiv(num1: $rem, num2: self::NS_PER_MS);
-            $rem = $rem % self::NS_PER_MS;
+            $rem %= self::NS_PER_MS;
             $us = intdiv(num1: $rem, num2: self::NS_PER_US);
             $ns = $rem % self::NS_PER_US;
 
@@ -2147,7 +2149,7 @@ final class PlainDateTime implements Stringable
             }
             $perUnit = $timeUnitNs[$unit];
             $val = intdiv(num1: $rem, num2: $perUnit);
-            $rem = $rem % $perUnit;
+            $rem %= $perUnit;
             match ($unit) {
                 'hour' => $h = $val,
                 'minute' => $min = $val,
@@ -2247,7 +2249,7 @@ final class PlainDateTime implements Stringable
             $newTimeNs -= $overflowDays * self::NS_PER_DAY;
         } else {
             $overflowDays = intdiv(num1: $newTimeNs, num2: self::NS_PER_DAY);
-            $newTimeNs = $newTimeNs % self::NS_PER_DAY;
+            $newTimeNs %= self::NS_PER_DAY;
         }
 
         $days += $overflowDays;
@@ -2276,11 +2278,11 @@ final class PlainDateTime implements Stringable
         $h = intdiv(num1: $newTimeNs, num2: self::NS_PER_HOUR);
         $rem = $newTimeNs % self::NS_PER_HOUR;
         $min = intdiv(num1: $rem, num2: self::NS_PER_MINUTE);
-        $rem = $rem % self::NS_PER_MINUTE;
+        $rem %= self::NS_PER_MINUTE;
         $sec = intdiv(num1: $rem, num2: self::NS_PER_SECOND);
-        $rem = $rem % self::NS_PER_SECOND;
+        $rem %= self::NS_PER_SECOND;
         $msR = intdiv(num1: $rem, num2: self::NS_PER_MS);
-        $rem = $rem % self::NS_PER_MS;
+        $rem %= self::NS_PER_MS;
         $usR = intdiv(num1: $rem, num2: self::NS_PER_US);
         $nsR = $rem % self::NS_PER_US;
 

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -1287,9 +1287,11 @@ final class PlainMonthDay implements Stringable
             // Find the maximum constrained day.
             $maxConstrainedDay = 0;
             foreach ($constrainedCandidates as $c) {
-                if ($c['day'] > $maxConstrainedDay) {
-                    $maxConstrainedDay = $c['day'];
+                if ($c['day'] <= $maxConstrainedDay) {
+                    continue;
                 }
+
+                $maxConstrainedDay = $c['day'];
             }
             // Now find the reference year for the constrained monthCode+day.
             return self::resolveNonIsoReferenceYear($calendar, $calendarId, $monthCode, $maxConstrainedDay, 'reject');

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -1320,6 +1320,7 @@ final class PlainMonthDay implements Stringable
     private static function extractCalendarId(string $cal): string
     {
         if (str_contains($cal, '[')) {
+            $m = null;
             if (preg_match('/\[!?u-ca=([^\]]+)\]/', $cal, $m) === 1) {
                 return strtolower($m[1]);
             }

--- a/src/Spec/PlainTime.php
+++ b/src/Spec/PlainTime.php
@@ -544,7 +544,7 @@ final class PlainTime implements Stringable
         $h = intdiv(num1: $nsToFormat, num2: self::NS_PER_HOUR);
         $rem = $nsToFormat % self::NS_PER_HOUR;
         $min = intdiv(num1: $rem, num2: self::NS_PER_MINUTE);
-        $rem = $rem % self::NS_PER_MINUTE;
+        $rem %= self::NS_PER_MINUTE;
         $sec = intdiv(num1: $rem, num2: self::NS_PER_SECOND);
         // Sub-second nanoseconds (0–999_999_999).
         $subNs = $rem % self::NS_PER_SECOND;
@@ -597,11 +597,11 @@ final class PlainTime implements Stringable
         $h = intdiv(num1: $nsTotal, num2: self::NS_PER_HOUR);
         $rem = $nsTotal % self::NS_PER_HOUR;
         $min = intdiv(num1: $rem, num2: self::NS_PER_MINUTE);
-        $rem = $rem % self::NS_PER_MINUTE;
+        $rem %= self::NS_PER_MINUTE;
         $sec = intdiv(num1: $rem, num2: self::NS_PER_SECOND);
-        $rem = $rem % self::NS_PER_SECOND;
+        $rem %= self::NS_PER_SECOND;
         $ms = intdiv(num1: $rem, num2: self::NS_PER_MS);
-        $rem = $rem % self::NS_PER_MS;
+        $rem %= self::NS_PER_MS;
         $us = intdiv(num1: $rem, num2: self::NS_PER_US);
         $ns = $rem % self::NS_PER_US;
         return new self($h, $min, $sec, $ms, $us, $ns);
@@ -1113,23 +1113,23 @@ final class PlainTime implements Stringable
 
         if ($luRank >= 6) {
             $hours = intdiv(num1: $remaining, num2: self::NS_PER_HOUR);
-            $remaining = $remaining % self::NS_PER_HOUR;
+            $remaining %= self::NS_PER_HOUR;
         }
         if ($luRank >= 5) {
             $minutes = intdiv(num1: $remaining, num2: self::NS_PER_MINUTE);
-            $remaining = $remaining % self::NS_PER_MINUTE;
+            $remaining %= self::NS_PER_MINUTE;
         }
         if ($luRank >= 4) {
             $seconds = intdiv(num1: $remaining, num2: self::NS_PER_SECOND);
-            $remaining = $remaining % self::NS_PER_SECOND;
+            $remaining %= self::NS_PER_SECOND;
         }
         if ($luRank >= 3) {
             $ms = intdiv(num1: $remaining, num2: self::NS_PER_MS);
-            $remaining = $remaining % self::NS_PER_MS;
+            $remaining %= self::NS_PER_MS;
         }
         if ($luRank >= 2) {
             $us = intdiv(num1: $remaining, num2: self::NS_PER_US);
-            $remaining = $remaining % self::NS_PER_US;
+            $remaining %= self::NS_PER_US;
         }
         $ns = $remaining;
 

--- a/src/Spec/PlainYearMonth.php
+++ b/src/Spec/PlainYearMonth.php
@@ -1541,6 +1541,7 @@ final class PlainYearMonth implements Stringable
     private static function extractCalendarId(string $cal): string
     {
         if (str_contains($cal, '[')) {
+            $m = null;
             if (preg_match('/\[!?u-ca=([^\]]+)\]/', $cal, $m) === 1) {
                 return strtolower($m[1]);
             }

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -1372,10 +1372,12 @@ final class ZonedDateTime implements Stringable
         ];
         $hasField = false;
         foreach ($recognized as $f) {
-            if (array_key_exists($f, $fields)) {
-                $hasField = true;
-                break;
+            if (!array_key_exists($f, $fields)) {
+                continue;
             }
+
+            $hasField = true;
+            break;
         }
         if (!$hasField) {
             throw new \TypeError('ZonedDateTime::with() requires at least one recognized property.');
@@ -4022,7 +4024,7 @@ final class ZonedDateTime implements Stringable
             // Use DST-aware day length for IANA timezones.
             $nsPerDayForOverflow = (int) $nsPerDayF;
             $overflowDays = intdiv(num1: $absTimeNs, num2: $nsPerDayForOverflow);
-            $absTimeNs = $absTimeNs % $nsPerDayForOverflow;
+            $absTimeNs %= $nsPerDayForOverflow;
             $days += $overflowDays;
 
             // Re-balance calendar units when day overflow pushes past month boundaries.
@@ -4070,11 +4072,11 @@ final class ZonedDateTime implements Stringable
             $h = intdiv(num1: $absTimeNs, num2: 3_600_000_000_000);
             $rem = $absTimeNs % 3_600_000_000_000;
             $min = intdiv(num1: $rem, num2: 60_000_000_000);
-            $rem = $rem % 60_000_000_000;
+            $rem %= 60_000_000_000;
             $sec = intdiv(num1: $rem, num2: self::NS_PER_SECOND);
-            $rem = $rem % self::NS_PER_SECOND;
+            $rem %= self::NS_PER_SECOND;
             $msR = intdiv(num1: $rem, num2: self::NS_PER_MILLISECOND);
-            $rem = $rem % self::NS_PER_MILLISECOND;
+            $rem %= self::NS_PER_MILLISECOND;
             $usR = intdiv(num1: $rem, num2: self::NS_PER_MICROSECOND);
             $nsR = $rem % self::NS_PER_MICROSECOND;
 

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -3892,7 +3892,7 @@ final class ZonedDateTime implements Stringable
                     // Keep wall-clock timeDiffNs on failure
                     unset($e);
                 }
-            } elseif ($isIanaTz && $years === 0 && $months === 0 && $weeks === 0 && $days === 0) {
+            } elseif ($isIanaTz) {
                 // Same date, no date diff: use raw epoch diff for the time part.
                 $absDiffNsSameDay = $sign < 0 ? -$diffNs : $diffNs;
                 if ($absDiffNsSameDay >= 0) {

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -1898,6 +1898,7 @@ final class ZonedDateTime implements Stringable
             throw new InvalidArgumentException("Invalid calendar \"{$s}\": minus-zero year.");
         }
         // Check for [u-ca=X] annotation.
+        $m = null;
         if (preg_match('/\[u-ca=([^\]]+)\]/', $s, $m) === 1) {
             return CalendarFactory::canonicalize($m[1]);
         }
@@ -1958,6 +1959,7 @@ final class ZonedDateTime implements Stringable
                 );
             }
             // Bracket annotation takes precedence.
+            $bm = null;
             if (preg_match('/\[(!?[^\]]+)\]/', $id, $bm) === 1) {
                 $bracket = $bm[1];
                 if (preg_match('/^[+\-]\d{2}:\d{2}:\d{2}/', $bracket) === 1) {
@@ -1991,6 +1993,7 @@ final class ZonedDateTime implements Stringable
             if (preg_match('/[Zz](?:\[|$)/', $id) === 1) {
                 return 'UTC';
             }
+            $om = null;
             if (preg_match('/([+\-]\d{2}:\d{2})(?:\[|$)/', $id, $om) === 1) {
                 return $om[1];
             }
@@ -2005,6 +2008,7 @@ final class ZonedDateTime implements Stringable
             return $id;
         }
         // ±HHMM → ±HH:MM
+        $m = null;
         if (preg_match('/^([+\-])(\d{2})(\d{2})$/', $id, $m) === 1) {
             return sprintf('%s%s:%s', $m[1], $m[2], $m[3]);
         }
@@ -2240,6 +2244,7 @@ final class ZonedDateTime implements Stringable
             return 0;
         }
         // Fixed offset ±HH:MM.
+        $m = null;
         if (preg_match('/^([+\-])(\d{2}):(\d{2})$/', $this->resolvedTimeZoneId, $m) === 1) {
             $sign = $m[1] === '+' ? 1 : -1;
             return $sign * (((int) $m[2] * 3600) + ((int) $m[3] * 60));
@@ -2843,6 +2848,7 @@ final class ZonedDateTime implements Stringable
      */
     private static function extractTzFromAnnotations(string $section, string $original): array
     {
+        $matches = null;
         preg_match_all('/\[(!?)([^\]]*)\]/', $section, $matches, PREG_SET_ORDER);
 
         $tzId = null;
@@ -2987,6 +2993,7 @@ final class ZonedDateTime implements Stringable
             return $wallSec;
         }
         // Fixed offset ±HH:MM.
+        $m = null;
         if (preg_match('/^([+\-])(\d{2}):(\d{2})$/', $tzId, $m) === 1) {
             $sign = $m[1] === '+' ? 1 : -1;
             $offsetSec = $sign * (((int) $m[2] * 3600) + ((int) $m[3] * 60));
@@ -3074,6 +3081,7 @@ final class ZonedDateTime implements Stringable
         if ($tzId === 'UTC') {
             return 0;
         }
+        $m = null;
         if (preg_match('/^([+\-])(\d{2}):(\d{2})$/', $tzId, $m) === 1) {
             $sign = $m[1] === '+' ? 1 : -1;
             return $sign * (((int) $m[2] * 3600) + ((int) $m[3] * 60));

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -497,7 +497,7 @@ final class ZonedDateTime implements \Stringable, \JsonSerializable
                 'nanosecond' => $nanosecond,
                 'offset' => $offset,
             ],
-            fn($v) => $v !== null,
+            static fn($v) => $v !== null,
         );
 
         if ($monthCode !== null) {

--- a/tests/Porcelain/Constraint/DurationEquals.php
+++ b/tests/Porcelain/Constraint/DurationEquals.php
@@ -84,9 +84,11 @@ final class DurationEquals extends Constraint
         $lines = [];
 
         foreach (self::FIELDS as $field) {
-            if ($expected[$field] !== $actual[$field]) {
-                $lines[] = sprintf('  %s: expected %d, actual %d', $field, $expected[$field], $actual[$field]);
+            if ($expected[$field] === $actual[$field]) {
+                continue;
             }
+
+            $lines[] = sprintf('  %s: expected %d, actual %d', $field, $expected[$field], $actual[$field]);
         }
 
         return implode("\n", $lines);
@@ -104,7 +106,7 @@ final class DurationEquals extends Constraint
 
         $parts = [];
         foreach ($nonZero as $name => $value) {
-            $parts[] = "$name: $value";
+            $parts[] = "{$name}: {$value}";
         }
 
         return sprintf('Duration {%s}', implode(', ', $parts));

--- a/tests/Porcelain/Constraint/PlainTimeEquals.php
+++ b/tests/Porcelain/Constraint/PlainTimeEquals.php
@@ -73,9 +73,11 @@ final class PlainTimeEquals extends Constraint
         $lines = [];
 
         foreach (self::FIELDS as $field) {
-            if ($expected[$field] !== $actual[$field]) {
-                $lines[] = sprintf('  %s: expected %d, actual %d', $field, $expected[$field], $actual[$field]);
+            if ($expected[$field] === $actual[$field]) {
+                continue;
             }
+
+            $lines[] = sprintf('  %s: expected %d, actual %d', $field, $expected[$field], $actual[$field]);
         }
 
         return implode("\n", $lines);

--- a/tests/Porcelain/PlainTimeTest.php
+++ b/tests/Porcelain/PlainTimeTest.php
@@ -6,7 +6,6 @@ namespace Temporal\Tests\Porcelain;
 
 use InvalidArgumentException;
 use Temporal\Duration;
-use Temporal\Overflow;
 use Temporal\PlainTime;
 use Temporal\RoundingMode;
 use Temporal\Unit;

--- a/tests/Test262/RunnerTest.php
+++ b/tests/Test262/RunnerTest.php
@@ -30,10 +30,12 @@ final class RunnerTest extends TestCase
         ));
         /** @var \SplFileInfo $file */
         foreach ($it as $file) {
-            if ($file->getExtension() === 'php') {
-                $name = ltrim(str_replace(search: $dir, replace: '', subject: $file->getPathname()), characters: '/');
-                yield $name => [$file->getPathname()];
+            if ($file->getExtension() !== 'php') {
+                continue;
             }
+
+            $name = ltrim(str_replace(search: $dir, replace: '', subject: $file->getPathname()), characters: '/');
+            yield $name => [$file->getPathname()];
         }
     }
 


### PR DESCRIPTION
## Summary

Four small commits driven by running Mago's linter and analyzer across the codebase:

1. **`7c35bb11` Apply mago lint --fix mechanical cleanup** — `prefer-early-continue`, `use-compound-assignment`, `prefer-static-closure` auto-fixes, plus one manual `prefer-arrow-function` conversion in `Duration::toIntSafe()` helper.

2. **`333ec40b` Promote `prefer-early-continue` to error** — no existing violations after commit 1, so the rule promotion is a no-op today but prevents regressions.

3. **`76e5ad43` Pre-initialize `preg_match` output parameters to `null`** — silences Mago analyzer's `reference-to-undefined-variable` warnings at 48 call sites. Documents intent instead of relying on PHP's implicit auto-vivification through reference.

4. **`0cfa9fc5` Drop genuinely redundant conditions** — two spots flagged by Mago's analyzer that really are redundant:
   - `Duration::round()` pure-time branch: dropped `!$needsRelativeTo` conjunct that was already documented as always-true, along with the paired `@psalm-suppress` / `@phpstan-ignore` annotations.
   - `ZonedDateTime::calendarDiff()`: simplified `elseif ($isIanaTz && $years === 0 && $months === 0 && $weeks === 0 && $days === 0)` to just `elseif ($isIanaTz)` — the zero checks are guaranteed by the preceding `if` condition.

## False positives filed upstream

Several other Mago `redundant-*` / `reference-to-undefined-variable` diagnostics turned out to be false positives. Filed minimal repros with the Mago maintainers:

- carthage-software/mago#1701 — modulo-narrowing on a small-int union
- carthage-software/mago#1702 — `(int) \$float` cast narrowing that drops `PHP_INT_MIN`
- carthage-software/mago#1703 — `mixed` narrowed to `non-empty-countable` after `!== null && !== []`

## Verification

All green at each commit:

- PHPStan: ✅ No errors
- Psalm: ✅ No errors found
- PHPUnit: ✅ 7504 tests, 496127 assertions pass (the 1466 "incomplete" are pre-existing test262 skips)
- `mago lint`: 0 errors, 0 warnings regressed (2 pre-existing warnings unchanged)
- `mago analyze`: 0 errors, 0 warnings

## Test plan

- [ ] CI green
- [ ] `composer test` passes
- [ ] `composer check` passes
- [ ] spot-check the two redundant-condition drops read correctly in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)