### PR TITLE
Extract virtual property hooks into @internal traits

### DIFF
--- a/src/Instant.php
+++ b/src/Instant.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Temporal;
 
+use Temporal\Trait\HasEpochProperties;
+use Temporal\Trait\HasEpochSpec;
+
 /**
  * A fixed point in time with nanosecond precision.
  *
@@ -12,25 +15,9 @@ namespace Temporal;
  * simpler API surface for application code while delegating all computation
  * to the spec layer.
  */
-final class Instant implements \Stringable, \JsonSerializable
+final class Instant implements \Stringable, \JsonSerializable, HasEpochSpec
 {
-    /**
-     * Nanoseconds since the Unix epoch (1970-01-01T00:00:00Z).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $epochNanoseconds {
-        get => $this->spec->epochNanoseconds;
-    }
-
-    /**
-     * Milliseconds since the Unix epoch (floor-divided from nanoseconds).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $epochMilliseconds {
-        get => $this->spec->epochMilliseconds;
-    }
+    use HasEpochProperties;
 
     /** The underlying spec-layer instance. */
     private readonly Spec\Instant $spec;

--- a/src/PlainDate.php
+++ b/src/PlainDate.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Temporal;
 
 use Temporal\Spec\PlainDate as SpecPlainDate;
+use Temporal\Trait\HasDayOfMonthProperties;
+use Temporal\Trait\HasDayOfMonthSpec;
+use Temporal\Trait\HasYearMonthProperties;
+use Temporal\Trait\HasYearMonthSpec;
 
 /**
  * A calendar date without a time or time zone.
@@ -13,160 +17,10 @@ use Temporal\Spec\PlainDate as SpecPlainDate;
  * {@see SpecPlainDate}. It provides typed enums, named parameters, and
  * value-object semantics while delegating all calendar math to the spec layer.
  */
-final class PlainDate implements \Stringable, \JsonSerializable
+final class PlainDate implements \Stringable, \JsonSerializable, HasYearMonthSpec, HasDayOfMonthSpec
 {
-    // -------------------------------------------------------------------------
-    // Virtual (get-only) properties — delegated to the spec instance
-    // -------------------------------------------------------------------------
-
-    /**
-     * Calendar year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $year {
-        get => $this->spec->year;
-    }
-
-    /**
-     * Month of the year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $month {
-        get => $this->spec->month;
-    }
-
-    /**
-     * Day of the month (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $day {
-        get => $this->spec->day;
-    }
-
-    /**
-     * Calendar system for this date.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public Calendar $calendar {
-        get => Calendar::from($this->spec->calendarId);
-    }
-
-    /**
-     * Calendar era identifier (e.g. "ce", "bce", "reiwa"), or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?string $era {
-        get => $this->spec->era;
-    }
-
-    /**
-     * Year within the calendar era, or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $eraYear {
-        get => $this->spec->eraYear;
-    }
-
-    /**
-     * Month code in "M01"–"M12" format (or "M01L"–"M12L" for leap months).
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public string $monthCode {
-        get => $this->spec->monthCode;
-    }
-
-    /**
-     * ISO 8601 day of week: 1 = Monday, 7 = Sunday.
-     *
-     * @var int<1, 7>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $dayOfWeek {
-        get => $this->spec->dayOfWeek;
-    }
-
-    /**
-     * Ordinal day of the year (1-based). Range depends on the calendar system.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $dayOfYear {
-        get => $this->spec->dayOfYear;
-    }
-
-    /**
-     * ISO 8601 week number: 1–53, or null for non-ISO calendars.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $weekOfYear {
-        get => $this->spec->weekOfYear;
-    }
-
-    /**
-     * ISO 8601 week-year (may differ from calendar year near year boundaries),
-     * or null for non-ISO calendars.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $yearOfWeek {
-        get => $this->spec->yearOfWeek;
-    }
-
-    /**
-     * Number of days in this date's month.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInMonth {
-        get => $this->spec->daysInMonth;
-    }
-
-    /**
-     * Days in a week (always 7).
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInWeek {
-        get => $this->spec->daysInWeek;
-    }
-
-    /**
-     * Number of days in this date's year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInYear {
-        get => $this->spec->daysInYear;
-    }
-
-    /**
-     * Number of months in this date's year.
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $monthsInYear {
-        get => $this->spec->monthsInYear;
-    }
-
-    /**
-     * True if this date's year is a leap year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public bool $inLeapYear {
-        get => $this->spec->inLeapYear;
-    }
+    use HasYearMonthProperties;
+    use HasDayOfMonthProperties;
 
     // -------------------------------------------------------------------------
     // Constructor

--- a/src/PlainDateTime.php
+++ b/src/PlainDateTime.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace Temporal;
 
 use Temporal\Spec\PlainDateTime as SpecPlainDateTime;
+use Temporal\Trait\HasDayOfMonthProperties;
+use Temporal\Trait\HasDayOfMonthSpec;
+use Temporal\Trait\HasTimeOfDayProperties;
+use Temporal\Trait\HasTimeOfDaySpec;
+use Temporal\Trait\HasYearMonthProperties;
+use Temporal\Trait\HasYearMonthSpec;
 
 /**
  * A calendar date combined with a wall-clock time, without a time zone.
@@ -13,219 +19,16 @@ use Temporal\Spec\PlainDateTime as SpecPlainDateTime;
  * {@see SpecPlainDateTime}. It provides typed enums, named parameters, and
  * value-object semantics while delegating all calendar math to the spec layer.
  */
-final class PlainDateTime implements \Stringable, \JsonSerializable
+final class PlainDateTime implements
+    \Stringable,
+    \JsonSerializable,
+    HasYearMonthSpec,
+    HasDayOfMonthSpec,
+    HasTimeOfDaySpec
 {
-    // -------------------------------------------------------------------------
-    // Virtual (get-only) properties — delegated to the spec instance
-    // -------------------------------------------------------------------------
-
-    /**
-     * Calendar year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $year {
-        get => $this->spec->year;
-    }
-
-    /**
-     * Month of the year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $month {
-        get => $this->spec->month;
-    }
-
-    /**
-     * Day of the month (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $day {
-        get => $this->spec->day;
-    }
-
-    /**
-     * Hour of the day (0–23).
-     *
-     * @var int<0, 23>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $hour {
-        get => $this->spec->hour;
-    }
-
-    /**
-     * Minute of the hour (0–59).
-     *
-     * @var int<0, 59>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $minute {
-        get => $this->spec->minute;
-    }
-
-    /**
-     * Second of the minute (0–59).
-     *
-     * @var int<0, 59>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $second {
-        get => $this->spec->second;
-    }
-
-    /**
-     * Millisecond (0–999).
-     *
-     * @var int<0, 999>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $millisecond {
-        get => $this->spec->millisecond;
-    }
-
-    /**
-     * Microsecond (0–999).
-     *
-     * @var int<0, 999>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $microsecond {
-        get => $this->spec->microsecond;
-    }
-
-    /**
-     * Nanosecond (0–999).
-     *
-     * @var int<0, 999>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $nanosecond {
-        get => $this->spec->nanosecond;
-    }
-
-    /**
-     * Calendar system for this datetime.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public Calendar $calendar {
-        get => Calendar::from($this->spec->calendarId);
-    }
-
-    /**
-     * Calendar era identifier (e.g. "ce", "bce", "reiwa"), or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?string $era {
-        get => $this->spec->era;
-    }
-
-    /**
-     * Year within the calendar era, or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $eraYear {
-        get => $this->spec->eraYear;
-    }
-
-    /**
-     * Month code in "M01"–"M12" format (or "M01L"–"M12L" for leap months).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public string $monthCode {
-        get => $this->spec->monthCode;
-    }
-
-    /**
-     * ISO 8601 day of week: 1 = Monday, 7 = Sunday.
-     *
-     * @var int<1, 7>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $dayOfWeek {
-        get => $this->spec->dayOfWeek;
-    }
-
-    /**
-     * Ordinal day of the year (1-based). Range depends on the calendar system.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $dayOfYear {
-        get => $this->spec->dayOfYear;
-    }
-
-    /**
-     * ISO 8601 week number: 1–53, or null for non-ISO calendars.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $weekOfYear {
-        get => $this->spec->weekOfYear;
-    }
-
-    /**
-     * ISO 8601 week-year (may differ from calendar year near year boundaries),
-     * or null for non-ISO calendars.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $yearOfWeek {
-        get => $this->spec->yearOfWeek;
-    }
-
-    /**
-     * Number of days in this date's month.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInMonth {
-        get => $this->spec->daysInMonth;
-    }
-
-    /**
-     * Days in a week (always 7).
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInWeek {
-        get => $this->spec->daysInWeek;
-    }
-
-    /**
-     * Number of days in this date's year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInYear {
-        get => $this->spec->daysInYear;
-    }
-
-    /**
-     * Number of months in this date's year.
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $monthsInYear {
-        get => $this->spec->monthsInYear;
-    }
-
-    /**
-     * True if this date's year is a leap year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public bool $inLeapYear {
-        get => $this->spec->inLeapYear;
-    }
+    use HasYearMonthProperties;
+    use HasDayOfMonthProperties;
+    use HasTimeOfDayProperties;
 
     // -------------------------------------------------------------------------
     // Constructor

--- a/src/PlainTime.php
+++ b/src/PlainTime.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Temporal;
 
 use Temporal\Spec\PlainTime as SpecPlainTime;
+use Temporal\Trait\HasTimeOfDayProperties;
+use Temporal\Trait\HasTimeOfDaySpec;
 
 /**
  * A wall-clock time without a date or time zone.
@@ -12,55 +14,9 @@ use Temporal\Spec\PlainTime as SpecPlainTime;
  * This is the porcelain wrapper around {@see SpecPlainTime}, providing a
  * type-safe PHP API with enums instead of raw option arrays.
  */
-final class PlainTime implements \Stringable, \JsonSerializable
+final class PlainTime implements \Stringable, \JsonSerializable, HasTimeOfDaySpec
 {
-    /**
-     * @var int
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $hour {
-        get => $this->spec->hour;
-    }
-
-    /**
-     * @var int
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $minute {
-        get => $this->spec->minute;
-    }
-
-    /**
-     * @var int
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $second {
-        get => $this->spec->second;
-    }
-
-    /**
-     * @var int
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $millisecond {
-        get => $this->spec->millisecond;
-    }
-
-    /**
-     * @var int
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $microsecond {
-        get => $this->spec->microsecond;
-    }
-
-    /**
-     * @var int
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $nanosecond {
-        get => $this->spec->nanosecond;
-    }
+    use HasTimeOfDayProperties;
 
     private readonly SpecPlainTime $spec;
 

--- a/src/PlainYearMonth.php
+++ b/src/PlainYearMonth.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Temporal;
 
 use Temporal\Spec\PlainYearMonth as SpecPlainYearMonth;
+use Temporal\Trait\HasYearMonthProperties;
+use Temporal\Trait\HasYearMonthSpec;
 
 /**
  * A calendar year-month without a specific day, time, or time zone.
@@ -13,102 +15,9 @@ use Temporal\Spec\PlainYearMonth as SpecPlainYearMonth;
  * {@see SpecPlainYearMonth}. It provides typed enums, named parameters, and
  * value-object semantics while delegating all calendar math to the spec layer.
  */
-final class PlainYearMonth implements \Stringable, \JsonSerializable
+final class PlainYearMonth implements \Stringable, \JsonSerializable, HasYearMonthSpec
 {
-    // -------------------------------------------------------------------------
-    // Virtual (get-only) properties — delegated to the spec instance
-    // -------------------------------------------------------------------------
-
-    /**
-     * Calendar year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $year {
-        get => $this->spec->year;
-    }
-
-    /**
-     * Month of the year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $month {
-        get => $this->spec->month;
-    }
-
-    /**
-     * Calendar system used by this year-month.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public Calendar $calendar {
-        get => Calendar::from($this->spec->calendarId);
-    }
-
-    /**
-     * Calendar era identifier (e.g. "ce", "bce", "reiwa"), or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?string $era {
-        get => $this->spec->era;
-    }
-
-    /**
-     * Year within the calendar era, or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $eraYear {
-        get => $this->spec->eraYear;
-    }
-
-    /**
-     * Month code in "M01"–"M12" format (or "M01L"–"M12L" for leap months).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public string $monthCode {
-        get => $this->spec->monthCode;
-    }
-
-    /**
-     * Number of days in this year-month's month.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInMonth {
-        get => $this->spec->daysInMonth;
-    }
-
-    /**
-     * Number of days in this year-month's year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $daysInYear {
-        get => $this->spec->daysInYear;
-    }
-
-    /**
-     * Number of months in this year-month's year.
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public int $monthsInYear {
-        get => $this->spec->monthsInYear;
-    }
-
-    /**
-     * True if this year-month's year is a leap year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public bool $inLeapYear {
-        get => $this->spec->inLeapYear;
-    }
+    use HasYearMonthProperties;
 
     // -------------------------------------------------------------------------
     // Constructor

--- a/src/Trait/HasDayOfMonthProperties.php
+++ b/src/Trait/HasDayOfMonthProperties.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+/**
+ * Virtual (get-only) day-of-month properties that delegate to a spec
+ * instance accessible via `$this->spec`.
+ *
+ * Used by outer-layer wrapper classes (PlainDate, PlainDateTime,
+ * ZonedDateTime) to share property-hook declarations that would otherwise
+ * be copy-pasted. Composes with {@see HasYearMonthProperties}.
+ *
+ * @internal
+ * @phpstan-require-implements HasDayOfMonthSpec
+ * @psalm-require-implements HasDayOfMonthSpec
+ */
+trait HasDayOfMonthProperties
+{
+    /**
+     * Day of the month (projected through the active calendar).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $day {
+        get => $this->spec->day;
+    }
+
+    /**
+     * ISO 8601 day of week: 1 = Monday, 7 = Sunday.
+     *
+     * @var int<1, 7>
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $dayOfWeek {
+        get => $this->spec->dayOfWeek;
+    }
+
+    /**
+     * Ordinal day of the year (1-based). Range depends on the calendar system.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $dayOfYear {
+        get => $this->spec->dayOfYear;
+    }
+
+    /**
+     * ISO 8601 week number: 1–53, or null for non-ISO calendars.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public ?int $weekOfYear {
+        get => $this->spec->weekOfYear;
+    }
+
+    /**
+     * ISO 8601 week-year (may differ from calendar year near year boundaries),
+     * or null for non-ISO calendars.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public ?int $yearOfWeek {
+        get => $this->spec->yearOfWeek;
+    }
+
+    /**
+     * Days in a week (always 7 for ISO 8601).
+     *
+     * @psalm-api
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $daysInWeek {
+        get => $this->spec->daysInWeek;
+    }
+}

--- a/src/Trait/HasDayOfMonthSpec.php
+++ b/src/Trait/HasDayOfMonthSpec.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+use Temporal\Spec\PlainDate as SpecPlainDate;
+use Temporal\Spec\PlainDateTime as SpecPlainDateTime;
+use Temporal\Spec\ZonedDateTime as SpecZonedDateTime;
+
+/**
+ * Marker interface declaring that a class exposes a `$spec` property whose
+ * type has day-of-month, day-of-week, and week-of-year fields.
+ *
+ * Used only as a `@phpstan-require-implements` target by
+ * {@see HasDayOfMonthProperties} so static analyzers can resolve
+ * `$this->spec->day` etc. inside the trait.
+ *
+ * @internal
+ * @property-read SpecPlainDate|SpecPlainDateTime|SpecZonedDateTime $spec
+ */
+interface HasDayOfMonthSpec {}

--- a/src/Trait/HasEpochProperties.php
+++ b/src/Trait/HasEpochProperties.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+/**
+ * Virtual (get-only) Unix epoch properties that delegate to a spec instance
+ * accessible via `$this->spec`.
+ *
+ * Used by outer-layer wrapper classes (Instant, ZonedDateTime) to share
+ * property-hook declarations that would otherwise be copy-pasted.
+ *
+ * @internal
+ * @phpstan-require-implements HasEpochSpec
+ * @psalm-require-implements HasEpochSpec
+ */
+trait HasEpochProperties
+{
+    /**
+     * Nanoseconds since the Unix epoch (1970-01-01T00:00:00Z).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $epochNanoseconds {
+        get => $this->spec->epochNanoseconds;
+    }
+
+    /**
+     * Milliseconds since the Unix epoch (floor-divided from nanoseconds).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $epochMilliseconds {
+        get => $this->spec->epochMilliseconds;
+    }
+}

--- a/src/Trait/HasEpochSpec.php
+++ b/src/Trait/HasEpochSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+use Temporal\Spec\Instant as SpecInstant;
+use Temporal\Spec\ZonedDateTime as SpecZonedDateTime;
+
+/**
+ * Marker interface declaring that a class exposes a `$spec` property whose
+ * type has `$epochNanoseconds` and `$epochMilliseconds` fields.
+ *
+ * Used only as a `@phpstan-require-implements` target by
+ * {@see HasEpochProperties} so static analyzers can resolve
+ * `$this->spec->epochNanoseconds` etc. inside the trait.
+ *
+ * @internal
+ * @property-read SpecInstant|SpecZonedDateTime $spec
+ */
+interface HasEpochSpec {}

--- a/src/Trait/HasTimeOfDayProperties.php
+++ b/src/Trait/HasTimeOfDayProperties.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+/**
+ * Virtual (get-only) time-of-day properties that delegate to a spec
+ * instance accessible via `$this->spec`.
+ *
+ * Used by outer-layer wrapper classes (PlainTime, PlainDateTime,
+ * ZonedDateTime) to share property-hook declarations that would otherwise
+ * be copy-pasted.
+ *
+ * @internal
+ * @phpstan-require-implements HasTimeOfDaySpec
+ * @psalm-require-implements HasTimeOfDaySpec
+ */
+trait HasTimeOfDayProperties
+{
+    /**
+     * Hour of the day (0–23).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $hour {
+        get => $this->spec->hour;
+    }
+
+    /**
+     * Minute of the hour (0–59).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $minute {
+        get => $this->spec->minute;
+    }
+
+    /**
+     * Second of the minute (0–59).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $second {
+        get => $this->spec->second;
+    }
+
+    /**
+     * Millisecond within the second (0–999).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $millisecond {
+        get => $this->spec->millisecond;
+    }
+
+    /**
+     * Microsecond within the millisecond (0–999).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $microsecond {
+        get => $this->spec->microsecond;
+    }
+
+    /**
+     * Nanosecond within the microsecond (0–999).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $nanosecond {
+        get => $this->spec->nanosecond;
+    }
+}

--- a/src/Trait/HasTimeOfDaySpec.php
+++ b/src/Trait/HasTimeOfDaySpec.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+use Temporal\Spec\PlainDateTime as SpecPlainDateTime;
+use Temporal\Spec\PlainTime as SpecPlainTime;
+use Temporal\Spec\ZonedDateTime as SpecZonedDateTime;
+
+/**
+ * Marker interface declaring that a class exposes a `$spec` property whose
+ * type has hour/minute/second/ms/μs/ns fields.
+ *
+ * Used only as a `@phpstan-require-implements` target by
+ * {@see HasTimeOfDayProperties} so static analyzers can resolve
+ * `$this->spec->hour` etc. inside the trait.
+ *
+ * @internal
+ * @property-read SpecPlainTime|SpecPlainDateTime|SpecZonedDateTime $spec
+ */
+interface HasTimeOfDaySpec {}

--- a/src/Trait/HasYearMonthProperties.php
+++ b/src/Trait/HasYearMonthProperties.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+use Temporal\Calendar;
+
+/**
+ * Virtual (get-only) calendar year-month properties that delegate to a spec
+ * instance accessible via `$this->spec`.
+ *
+ * Used by outer-layer wrapper classes (PlainYearMonth, PlainDate,
+ * PlainDateTime, ZonedDateTime) to share property-hook declarations that
+ * would otherwise be copy-pasted. Each consumer must declare a `$spec`
+ * property whose type exposes the matching calendar-identity fields
+ * (year, month, calendarId, era, eraYear, monthCode, daysInMonth,
+ * daysInYear, monthsInYear, inLeapYear).
+ *
+ * @internal
+ * @phpstan-require-implements HasYearMonthSpec
+ * @psalm-require-implements HasYearMonthSpec
+ */
+trait HasYearMonthProperties
+{
+    /**
+     * Calendar year (projected through the active calendar).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $year {
+        get => $this->spec->year;
+    }
+
+    /**
+     * Month of the year (projected through the active calendar).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $month {
+        get => $this->spec->month;
+    }
+
+    /**
+     * Calendar system for this value.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public Calendar $calendar {
+        get => Calendar::from($this->spec->calendarId);
+    }
+
+    /**
+     * Calendar era identifier (e.g. "ce", "bce", "reiwa"), or null for calendars without eras.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public ?string $era {
+        get => $this->spec->era;
+    }
+
+    /**
+     * Year within the calendar era, or null for calendars without eras.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public ?int $eraYear {
+        get => $this->spec->eraYear;
+    }
+
+    /**
+     * Month code in "M01"–"M12" format (or "M01L"–"M12L" for leap months).
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public string $monthCode {
+        get => $this->spec->monthCode;
+    }
+
+    /**
+     * Number of days in this value's month.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $daysInMonth {
+        get => $this->spec->daysInMonth;
+    }
+
+    /**
+     * Number of days in this value's year.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $daysInYear {
+        get => $this->spec->daysInYear;
+    }
+
+    /**
+     * Number of months in this value's year.
+     *
+     * @psalm-api
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public int $monthsInYear {
+        get => $this->spec->monthsInYear;
+    }
+
+    /**
+     * True if this value's year is a leap year.
+     *
+     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
+     */
+    public bool $inLeapYear {
+        get => $this->spec->inLeapYear;
+    }
+}

--- a/src/Trait/HasYearMonthSpec.php
+++ b/src/Trait/HasYearMonthSpec.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Trait;
+
+use Temporal\Spec\PlainDate as SpecPlainDate;
+use Temporal\Spec\PlainDateTime as SpecPlainDateTime;
+use Temporal\Spec\PlainYearMonth as SpecPlainYearMonth;
+use Temporal\Spec\ZonedDateTime as SpecZonedDateTime;
+
+/**
+ * Marker interface declaring that a class exposes a `$spec` property whose
+ * type has year/month/calendar identity fields.
+ *
+ * Used only as a `@phpstan-require-implements` target by
+ * {@see HasYearMonthProperties} so static analyzers can resolve
+ * `$this->spec->year` etc. inside the trait.
+ *
+ * @internal
+ * @property-read SpecPlainYearMonth|SpecPlainDate|SpecPlainDateTime|SpecZonedDateTime $spec
+ */
+interface HasYearMonthSpec {}

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Temporal;
 
+use Temporal\Trait\HasDayOfMonthProperties;
+use Temporal\Trait\HasDayOfMonthSpec;
+use Temporal\Trait\HasEpochProperties;
+use Temporal\Trait\HasEpochSpec;
+use Temporal\Trait\HasTimeOfDayProperties;
+use Temporal\Trait\HasTimeOfDaySpec;
+use Temporal\Trait\HasYearMonthProperties;
+use Temporal\Trait\HasYearMonthSpec;
+
 /**
  * A date-time anchored to a specific time zone and instant.
  *
@@ -12,32 +21,21 @@ namespace Temporal;
  * a simpler API surface for application code while delegating all computation
  * to the spec layer.
  */
-final class ZonedDateTime implements \Stringable, \JsonSerializable
+final class ZonedDateTime implements
+    \Stringable,
+    \JsonSerializable,
+    HasEpochSpec,
+    HasYearMonthSpec,
+    HasDayOfMonthSpec,
+    HasTimeOfDaySpec
 {
-    // -------------------------------------------------------------------------
-    // Virtual (get-only) epoch properties
-    // -------------------------------------------------------------------------
-
-    /**
-     * Nanoseconds since the Unix epoch (1970-01-01T00:00:00Z).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $epochNanoseconds {
-        get => $this->spec->epochNanoseconds;
-    }
-
-    /**
-     * Milliseconds since the Unix epoch (floor-divided from nanoseconds).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $epochMilliseconds {
-        get => $this->spec->epochMilliseconds;
-    }
+    use HasEpochProperties;
+    use HasYearMonthProperties;
+    use HasDayOfMonthProperties;
+    use HasTimeOfDayProperties;
 
     // -------------------------------------------------------------------------
-    // Virtual (get-only) identity properties
+    // Virtual (get-only) time-zone-specific properties
     // -------------------------------------------------------------------------
 
     /**
@@ -48,110 +46,6 @@ final class ZonedDateTime implements \Stringable, \JsonSerializable
     public string $timeZoneId {
         get => $this->spec->timeZoneId;
     }
-
-    /**
-     * Calendar system used for date field projection.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public Calendar $calendar {
-        get => Calendar::from($this->spec->calendarId);
-    }
-
-    // -------------------------------------------------------------------------
-    // Virtual (get-only) date/time component properties
-    // -------------------------------------------------------------------------
-
-    /**
-     * Calendar year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $year {
-        get => $this->spec->year;
-    }
-
-    /**
-     * Month of the year (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $month {
-        get => $this->spec->month;
-    }
-
-    /**
-     * Day of the month (projected through the active calendar).
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $day {
-        get => $this->spec->day;
-    }
-
-    /**
-     * Hour of the day (0-23).
-     *
-     * @var int<0, 23>
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $hour {
-        get => $this->spec->hour;
-    }
-
-    /**
-     * Minute of the hour (0-59).
-     *
-     * @var int<0, 59>
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $minute {
-        get => $this->spec->minute;
-    }
-
-    /**
-     * Second of the minute (0-59).
-     *
-     * @var int<0, 59>
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $second {
-        get => $this->spec->second;
-    }
-
-    /**
-     * Millisecond within the second (0-999).
-     *
-     * @var int<0, 999>
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $millisecond {
-        get => $this->spec->millisecond;
-    }
-
-    /**
-     * Microsecond within the millisecond (0-999).
-     *
-     * @var int<0, 999>
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $microsecond {
-        get => $this->spec->microsecond;
-    }
-
-    /**
-     * Nanosecond within the microsecond (0-999).
-     *
-     * @var int<0, 999>
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $nanosecond {
-        get => $this->spec->nanosecond;
-    }
-
-    // -------------------------------------------------------------------------
-    // Virtual (get-only) offset properties
-    // -------------------------------------------------------------------------
 
     /**
      * The UTC offset string for this instant in this time zone (e.g. '+05:30').
@@ -169,122 +63,6 @@ final class ZonedDateTime implements \Stringable, \JsonSerializable
      */
     public int $offsetNanoseconds {
         get => $this->spec->offsetNanoseconds;
-    }
-
-    // -------------------------------------------------------------------------
-    // Virtual (get-only) calendar properties
-    // -------------------------------------------------------------------------
-
-    /**
-     * Calendar era identifier (e.g. "ce", "bce", "reiwa"), or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?string $era {
-        get => $this->spec->era;
-    }
-
-    /**
-     * Year within the calendar era, or null for calendars without eras.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $eraYear {
-        get => $this->spec->eraYear;
-    }
-
-    /**
-     * Month code in "M01"-"M12" format, or "M01L"-"M12L" for leap months.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public string $monthCode {
-        get => $this->spec->monthCode;
-    }
-
-    /**
-     * ISO 8601 day of week: 1 = Monday, 7 = Sunday.
-     *
-     * @var int<1, 7>
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $dayOfWeek {
-        get => $this->spec->dayOfWeek;
-    }
-
-    /**
-     * Ordinal day of the year: 1-366.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $dayOfYear {
-        get => $this->spec->dayOfYear;
-    }
-
-    /**
-     * ISO 8601 week number: 1-53, or null for non-ISO calendars.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $weekOfYear {
-        get => $this->spec->weekOfYear;
-    }
-
-    /**
-     * ISO 8601 week-year (may differ from calendar year near year boundaries),
-     * or null for non-ISO calendars.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    public ?int $yearOfWeek {
-        get => $this->spec->yearOfWeek;
-    }
-
-    /**
-     * Number of days in this date's month.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $daysInMonth {
-        get => $this->spec->daysInMonth;
-    }
-
-    /**
-     * Always 7 (ISO 8601 calendar).
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $daysInWeek {
-        get => $this->spec->daysInWeek;
-    }
-
-    /**
-     * Number of days in this date's year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $daysInYear {
-        get => $this->spec->daysInYear;
-    }
-
-    /**
-     * Number of months in this date's year.
-     *
-     * @psalm-api
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public int $monthsInYear {
-        get => $this->spec->monthsInYear;
-    }
-
-    /**
-     * True if this date's year is a leap year.
-     *
-     * @psalm-suppress PropertyNotSetInConstructor — virtual property (get-only hook, no backing store)
-     */
-    public bool $inLeapYear {
-        get => $this->spec->inLeapYear;
     }
 
     /**


### PR DESCRIPTION
## Summary

A `jscpd` pass over `src/` flagged 38 duplicate blocks covering **11.68% of lines** — almost all of it copy-pasted PHP 8.4 property hooks delegating to `$this->spec`. The porcelain wrappers repeat the same `public T $name { get => $this->spec->name; }` patterns for every virtual property in common.

Extract four `@internal` traits under the new `Temporal\Trait\` namespace:

| Trait | Properties | Consumers |
|---|---|---|
| `HasYearMonthProperties` | calendar, year, month, era, eraYear, monthCode, daysInMonth, daysInYear, monthsInYear, inLeapYear | `PlainYearMonth`, `PlainDate`, `PlainDateTime`, `ZonedDateTime` |
| `HasDayOfMonthProperties` | day, dayOfWeek, dayOfYear, weekOfYear, yearOfWeek, daysInWeek | `PlainDate`, `PlainDateTime`, `ZonedDateTime` |
| `HasTimeOfDayProperties` | hour, minute, second, millisecond, microsecond, nanosecond | `PlainTime`, `PlainDateTime`, `ZonedDateTime` |
| `HasEpochProperties` | epochNanoseconds, epochMilliseconds | `Instant`, `ZonedDateTime` |

Each consumer composes the subset it needs; `ZonedDateTime` uses all four plus keeps its timezone-specific getters (`timeZoneId`, `offset`, `offsetNanoseconds`, `hoursInDay`) inline since it is the only consumer. `PlainMonthDay` and `Duration` keep their small property sets inline for the same reason.

## Impact

`jscpd` re-run:

| | Before | After |
|---|---:|---:|
| Clones | 38 | 34 |
| Duplicated lines | 826 (11.68%) | 633 (9.55%) |
| `src/` total lines | 7,071 | 6,627 |

## Test plan

- [x] `phpstan analyse` — 0 errors
- [x] `psalm` — 0 errors, 99.68% type inference (unchanged from master)
- [x] `mago lint` — no new warnings (3 pre-existing unchanged)
- [x] `phpunit --testsuite=porcelain` — 889 tests, all green
- [x] Full `phpunit` suite — 7,504 tests, 0 failures (1,466 pre-existing `markTestIncomplete()` from test262)
- [ ] CI green

## Transparency

PR authored with Claude Code. The trait split, namespace choice (`Temporal\Trait\`, `@internal`-only), and the decision to leave `PlainMonthDay`/`Duration` inline as single-consumer property sets were approved interactively by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)