### PR TITLE
Extract day/week branch of dateUntil into CalendarMath helper

### DIFF
--- a/src/Spec/Internal/Calendar/IsoCalendar.php
+++ b/src/Spec/Internal/Calendar/IsoCalendar.php
@@ -171,17 +171,9 @@ final class IsoCalendar implements CalendarProtocol
         string $largestUnit,
         bool $receiverIsLater = false,
     ): array {
-        if ($largestUnit === 'day' || $largestUnit === 'week') {
-            $totalDays =
-                CalendarMath::toJulianDay($isoY2, $isoM2, $isoD2) - CalendarMath::toJulianDay($isoY1, $isoM1, $isoD1);
-            if ($largestUnit === 'week') {
-                $weeks = intdiv($totalDays, num2: 7);
-                $days = $totalDays - ($weeks * 7);
-
-                return [0, 0, $weeks, $days];
-            }
-
-            return [0, 0, 0, $totalDays];
+        $dayOrWeek = CalendarMath::dayOrWeekDateUntil($isoY1, $isoM1, $isoD1, $isoY2, $isoM2, $isoD2, $largestUnit);
+        if ($dayOrWeek !== null) {
+            return $dayOrWeek;
         }
 
         // Year/month decomposition.

--- a/src/Spec/Internal/Calendar/PureHebrewCalendar.php
+++ b/src/Spec/Internal/Calendar/PureHebrewCalendar.php
@@ -514,16 +514,9 @@ final class PureHebrewCalendar implements CalendarProtocol
         string $largestUnit,
         bool $receiverIsLater = false,
     ): array {
-        // Day/week: pure JDN subtraction.
-        if ($largestUnit === 'day' || $largestUnit === 'week') {
-            $totalDays =
-                CalendarMath::toJulianDay($isoY2, $isoM2, $isoD2) - CalendarMath::toJulianDay($isoY1, $isoM1, $isoD1);
-            if ($largestUnit === 'week') {
-                $weeks = intdiv($totalDays, num2: 7);
-                $days = $totalDays - ($weeks * 7);
-                return [0, 0, $weeks, $days];
-            }
-            return [0, 0, 0, $totalDays];
+        $dayOrWeek = CalendarMath::dayOrWeekDateUntil($isoY1, $isoM1, $isoD1, $isoY2, $isoM2, $isoD2, $largestUnit);
+        if ($dayOrWeek !== null) {
+            return $dayOrWeek;
         }
 
         $jdn1 = CalendarMath::toJulianDay($isoY1, $isoM1, $isoD1);

--- a/src/Spec/Internal/Calendar/PureIndianCalendar.php
+++ b/src/Spec/Internal/Calendar/PureIndianCalendar.php
@@ -310,15 +310,9 @@ final class PureIndianCalendar implements CalendarProtocol
         string $largestUnit,
         bool $receiverIsLater = false,
     ): array {
-        if ($largestUnit === 'day' || $largestUnit === 'week') {
-            $totalDays =
-                CalendarMath::toJulianDay($isoY2, $isoM2, $isoD2) - CalendarMath::toJulianDay($isoY1, $isoM1, $isoD1);
-            if ($largestUnit === 'week') {
-                $weeks = intdiv($totalDays, num2: 7);
-                $days = $totalDays - ($weeks * 7);
-                return [0, 0, $weeks, $days];
-            }
-            return [0, 0, 0, $totalDays];
+        $dayOrWeek = CalendarMath::dayOrWeekDateUntil($isoY1, $isoM1, $isoD1, $isoY2, $isoM2, $isoD2, $largestUnit);
+        if ($dayOrWeek !== null) {
+            return $dayOrWeek;
         }
 
         $jdn1 = CalendarMath::toJulianDay($isoY1, $isoM1, $isoD1);

--- a/src/Spec/Internal/CalendarMath.php
+++ b/src/Spec/Internal/CalendarMath.php
@@ -873,6 +873,40 @@ final class CalendarMath
     }
 
     /**
+     * Shared "day" / "week" early return for {@see CalendarProtocol::dateUntil()}.
+     *
+     * When `$largestUnit` is `'day'` or `'week'`, computes the signed difference
+     * purely from Julian Day Numbers — no calendar-specific year/month trial
+     * iteration is needed — and returns a `[years, months, weeks, days]` tuple.
+     * Returns `null` when `$largestUnit` is `'year'` or `'month'` so the caller
+     * falls through to its calendar-specific logic.
+     *
+     * @return array{int, int, int, int}|null
+     */
+    public static function dayOrWeekDateUntil(
+        int $isoY1,
+        int $isoM1,
+        int $isoD1,
+        int $isoY2,
+        int $isoM2,
+        int $isoD2,
+        string $largestUnit,
+    ): ?array {
+        if ($largestUnit !== 'day' && $largestUnit !== 'week') {
+            return null;
+        }
+
+        $totalDays = self::toJulianDay($isoY2, $isoM2, $isoD2) - self::toJulianDay($isoY1, $isoM1, $isoD1);
+
+        if ($largestUnit === 'week') {
+            $weeks = intdiv(num1: $totalDays, num2: 7);
+            return [0, 0, $weeks, $totalDays - ($weeks * 7)];
+        }
+
+        return [0, 0, 0, $totalDays];
+    }
+
+    /**
      * Strips year or day components from an ICU date pattern.
      *
      * For 'year': removes y, Y, u, U, r, G (era often pairs with year) pattern chars


### PR DESCRIPTION
## Summary

`PureHebrewCalendar::dateUntil()`, `PureIndianCalendar::dateUntil()`, and `IsoCalendar::dateUntil()` each opened with the same ~11-line block: convert both ISO dates to Julian Day Numbers, subtract, and return a `[years, months, weeks, days]` tuple when `$largestUnit` is `'day'` or `'week'`. The block has zero calendar-specific logic — it is pure JDN arithmetic — but was copy-pasted three times.

Extract `CalendarMath::dayOrWeekDateUntil()` returning `array|null`:

- returns the tuple when `$largestUnit` is `'day'` or `'week'`
- returns `null` for `'year'` / `'month'` so the caller falls through to its calendar-specific year/month logic

Each of the three `dateUntil()` implementations collapses to a 4-line guard at the top.

## Impact

`jscpd` re-run:

| | Before | After |
|---|---:|---:|
| Clones | 34 | 33 |
| Duplicated lines | 633 (9.55%) | 619 (9.32%) |

The gain is modest because the Hebrew ↔ Indian iterative year/month scaffolding still overlaps and is much larger. Extracting that would need a trait parameterizing on `isoToCalendarYear()` and a per-calendar `monthOvershootConstant`, plus keeping each calendar's own `trialDoesNotSurpass` since Hebrew's handling of Adar I/II leap months diverges materially from Indian's. Deferred — the day/week extraction is risk-free and atomic; the year/month one is not.

## Test plan

- [x] `phpstan analyse` — 0 errors
- [x] `psalm` — 0 errors, 99.68% type inference (unchanged)
- [x] `mago lint` — no new warnings
- [x] Calendar-related `phpunit --testsuite=porcelain` (`PlainDate|PlainYearMonth|PlainMonthDay|PlainDateTime|ZonedDateTime|NonIsoCalendar|CalendarArithmetic`) — 651 tests, all green
- [x] Full `phpunit` suite — 7,504 tests, 0 failures
- [ ] CI green

## Transparency

PR authored with Claude Code. The "day/week branch only" scope (vs. also extracting the Hebrew ↔ Indian year/month iteration) was an explicit maintainer call during review to keep the change risk-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)