### PR TITLE
perf: memoize hot paths in calendar/timezone code

### DIFF
--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -659,8 +659,6 @@ final class IntlCalendarBridge implements CalendarProtocol
             }
         }
 
-        $this->setIsoDate($isoYear, $isoMonth, $isoDay);
-
         if ($years !== 0 || $months !== 0) {
             // Capture the original calendar day and year/month. Use field-level
             // arithmetic: read calendar fields, add to year/month, resolve back.
@@ -668,6 +666,9 @@ final class IntlCalendarBridge implements CalendarProtocol
             // (japanese/buddhist/roc retain ICU's 1582 cutover; only the bare
             // gregorian IntlCalendar was made proleptic in the constructor).
             if ($this->isGregorianBased) {
+                // Fallback path only runs pre-1583 for buddhist/roc/japanese; the
+                // ICU state is needed to read the Julian-adjusted FIELD_DAY_OF_MONTH.
+                $this->setIsoDate($isoYear, $isoMonth, $isoDay);
                 $originalCalDay = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
                 $calYear = $this->calendarYear();
                 $calMonth = $this->calendarMonth();
@@ -675,6 +676,18 @@ final class IntlCalendarBridge implements CalendarProtocol
                 $originalCalDay = $this->day($isoYear, $isoMonth, $isoDay);
                 $calYear = $this->year($isoYear, $isoMonth, $isoDay);
                 $calMonth = $this->month($isoYear, $isoMonth, $isoDay);
+                // chinese/dangi/hebrew year-addition reads ICU fields directly below.
+                // setCalendarFields later calls intlCal->clear() which wipes state,
+                // so other non-gregorian calendars don't need setIsoDate at all.
+                if (
+                    $years !== 0 && (
+                        $this->calendarId === 'chinese'
+                        || $this->calendarId === 'dangi'
+                        || $this->calendarId === 'hebrew'
+                    )
+                ) {
+                    $this->setIsoDate($isoYear, $isoMonth, $isoDay);
+                }
             }
 
             // For calendars with leap months, year addition must preserve monthCode
@@ -745,15 +758,16 @@ final class IntlCalendarBridge implements CalendarProtocol
             if ($originalCalDay > $newMaxDay) {
                 $this->setCalendarFields($calYear, $calMonth, $newMaxDay);
             }
+            // State was set by setCalendarFields; trailing getTime reads that.
+            $epochMs = $this->intlCal->getTime();
+            $jdn = (int) floor($epochMs / (float) self::MS_PER_DAY) + 2_440_588;
+        } else {
+            // No year/month change: the starting ISO date is the current JDN —
+            // compute it directly without touching ICU.
+            $jdn = CalendarMath::toJulianDay($isoYear, $isoMonth, $isoDay);
         }
 
-        // Add weeks and days using JDN arithmetic (proleptic, no Julian cutover issue).
-        $epochMs = $this->intlCal->getTime();
-        $jdn = (int) floor($epochMs / (float) self::MS_PER_DAY) + 2_440_588;
-        $totalDays = ($weeks * 7) + $days;
-        $jdn += $totalDays;
-
-        return CalendarMath::fromJulianDay($jdn);
+        return CalendarMath::fromJulianDay($jdn + ($weeks * 7) + $days);
     }
 
     #[\Override]

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -822,10 +822,8 @@ final class IntlCalendarBridge implements CalendarProtocol
             // Year-only trial: check if the calendar day was constrained
             // (e.g. day 30 -> day 29 in a shorter month). If so, the trial
             // didn't preserve the exact date, so use strict inequality.
-            $this->setIsoDate($isoY1, $isoM1, $isoD1);
-            $origCalDay = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
-            $this->setIsoDate($tY, $tM, $tD);
-            $trialCalDay = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
+            $origCalDay = $this->day($isoY1, $isoM1, $isoD1);
+            $trialCalDay = $this->day($tY, $tM, $tD);
             $dayConstrained = $trialCalDay < $origCalDay;
 
             // For leap-month calendars, also check monthCode constraining.
@@ -836,10 +834,8 @@ final class IntlCalendarBridge implements CalendarProtocol
                 $trialMonthCode = $this->monthCode($tY, $tM, $tD);
                 if ($origMonthCode !== $trialMonthCode) {
                     $monthConstrained = true;
-                    $this->setIsoDate($isoY1, $isoM1, $isoD1);
-                    $origOrd = $this->calendarMonth();
-                    $this->setIsoDate($tY, $tM, $tD);
-                    $trialOrd = $this->calendarMonth();
+                    $origOrd = $this->month($isoY1, $isoM1, $isoD1);
+                    $trialOrd = $this->month($tY, $tM, $tD);
                     $constrainedOrdEarlier = $trialOrd < $origOrd;
                 }
             }
@@ -869,11 +865,8 @@ final class IntlCalendarBridge implements CalendarProtocol
         }
 
         // Month trials: check if day was constrained and adjust.
-        $this->setIsoDate($isoY1, $isoM1, $isoD1);
-        $origCalDay = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
-
-        $this->setIsoDate($tY, $tM, $tD);
-        $trialCalDay = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
+        $origCalDay = $this->day($isoY1, $isoM1, $isoD1);
+        $trialCalDay = $this->day($tY, $tM, $tD);
 
         if ($trialCalDay < $origCalDay) {
             // Day was constrained. Adjust the JDN to pretend the original day

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -208,8 +208,11 @@ final class IntlCalendarBridge implements CalendarProtocol
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
         $v = match (true) {
-            $this->calendarId === 'coptic', $this->calendarId === 'ethiopic' => $this->intlCal->get(self::FIELD_EXTENDED_YEAR),
-            $this->calendarId === 'chinese' => $this->intlCal->get(self::FIELD_EXTENDED_YEAR) - self::CHINESE_YEAR_OFFSET,
+            $this->calendarId === 'coptic',
+            $this->calendarId === 'ethiopic',
+                => $this->intlCal->get(self::FIELD_EXTENDED_YEAR),
+            $this->calendarId === 'chinese' => $this->intlCal->get(self::FIELD_EXTENDED_YEAR)
+                - self::CHINESE_YEAR_OFFSET,
             $this->calendarId === 'dangi' => $this->intlCal->get(self::FIELD_EXTENDED_YEAR) - self::DANGI_YEAR_OFFSET,
             default => $this->intlCal->get(\IntlCalendar::FIELD_YEAR),
         };
@@ -544,8 +547,12 @@ final class IntlCalendarBridge implements CalendarProtocol
     /**
      * @return array{0: int, 1: int<1, 12>, 2: int<1, 31>}
      */
-    private function calendarToIsoFromMonthCodeUncached(int $calYear, string $monthCode, int $calDay, string $overflow): array
-    {
+    private function calendarToIsoFromMonthCodeUncached(
+        int $calYear,
+        string $monthCode,
+        int $calDay,
+        string $overflow,
+    ): array {
         $isLeapCode = str_ends_with($monthCode, 'L');
 
         // For Chinese/Dangi leap month codes, first verify the leap month exists
@@ -643,8 +650,7 @@ final class IntlCalendarBridge implements CalendarProtocol
                 $calMonth -= 12;
                 $finalIsoYear++;
             }
-            $cutoverSafe = $this->calendarId === 'gregory'
-                || ($isoYear >= 1583 && $finalIsoYear >= 1583);
+            $cutoverSafe = $this->calendarId === 'gregory' || $isoYear >= 1583 && $finalIsoYear >= 1583;
             if ($cutoverSafe) {
                 /** @var int<1, 12> $calMonth */
                 $newMaxDay = CalendarMath::calcDaysInMonth($finalIsoYear, $calMonth);
@@ -680,7 +686,8 @@ final class IntlCalendarBridge implements CalendarProtocol
                 // setCalendarFields later calls intlCal->clear() which wipes state,
                 // so other non-gregorian calendars don't need setIsoDate at all.
                 if (
-                    $years !== 0 && (
+                    $years !== 0
+                    && (
                         $this->calendarId === 'chinese'
                         || $this->calendarId === 'dangi'
                         || $this->calendarId === 'hebrew'

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -759,7 +759,6 @@ final class IntlCalendarBridge implements CalendarProtocol
         // Read calendar fields.
         $this->setIsoDate($isoY1, $isoM1, $isoD1);
         $calY1 = $this->calendarYear();
-        $this->calendarMonth();
 
         $this->setIsoDate($isoY2, $isoM2, $isoD2);
         $calY2 = $this->calendarYear();

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -640,19 +640,12 @@ final class IntlCalendarBridge implements CalendarProtocol
         // equal the ISO fields, daysInMonth is pure ISO math, and monthsInYear
         // is 12.
         if ($this->isGregorianBased) {
-            $finalIsoYear = $isoYear + $years;
-            $calMonth = $isoMonth + $months;
-            while ($calMonth < 1) {
-                $finalIsoYear--;
-                $calMonth += 12;
-            }
-            while ($calMonth > 12) {
-                $calMonth -= 12;
-                $finalIsoYear++;
-            }
+            $totalMonths = $isoMonth + $months - 1;
+            $yearAdd = CalendarMath::floorDiv($totalMonths, 12);
+            $calMonth = $totalMonths - ($yearAdd * 12) + 1;
+            $finalIsoYear = $isoYear + $years + $yearAdd;
             $cutoverSafe = $this->calendarId === 'gregory' || $isoYear >= 1583 && $finalIsoYear >= 1583;
             if ($cutoverSafe) {
-                /** @var int<1, 12> $calMonth */
                 $newMaxDay = CalendarMath::calcDaysInMonth($finalIsoYear, $calMonth);
                 if ($overflow === 'reject' && $isoDay > $newMaxDay) {
                     throw new InvalidArgumentException(
@@ -1571,7 +1564,7 @@ final class IntlCalendarBridge implements CalendarProtocol
     /**
      * Reads back epoch ms from IntlCalendar, converts to ISO, and applies overflow handling.
      *
-     * @return array{0: int, 1: int, 2: int} [isoYear, isoMonth, isoDay]
+     * @return array{0: int, 1: int<1, 12>, 2: int<1, 31>} [isoYear, isoMonth, isoDay]
      */
     private function resolveAndConstrain(int $calDay, string $overflow): array
     {

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -625,6 +625,34 @@ final class IntlCalendarBridge implements CalendarProtocol
         int $days,
         string $overflow,
     ): array {
+        // Gregory fast path: the bare Gregorian IntlCalendar is forced proleptic
+        // in the constructor (setGregorianChange(PHP_FLOAT_MIN)), so calYear ==
+        // isoYear, calMonth == isoMonth, calDay == isoDay. Skip every intlCal
+        // round-trip in the year/month branch. Japanese/buddhist/roc retain
+        // ICU's 1582 Julian cutover, so they stay on the ICU path below.
+        if ($this->calendarId === 'gregory') {
+            $calYear = $isoYear + $years;
+            $calMonth = $isoMonth + $months;
+            while ($calMonth < 1) {
+                $calYear--;
+                $calMonth += 12;
+            }
+            while ($calMonth > 12) {
+                $calMonth -= 12;
+                $calYear++;
+            }
+            /** @var int<1, 12> $calMonth */
+            $newMaxDay = CalendarMath::calcDaysInMonth($calYear, $calMonth);
+            if ($overflow === 'reject' && $isoDay > $newMaxDay) {
+                throw new InvalidArgumentException(
+                    "Day {$isoDay} exceeds maximum {$newMaxDay} for the resulting calendar month.",
+                );
+            }
+            $finalDay = $isoDay > $newMaxDay ? $newMaxDay : $isoDay;
+            $jdn = CalendarMath::toJulianDay($calYear, $calMonth, $finalDay) + ($weeks * 7) + $days;
+            return CalendarMath::fromJulianDay($jdn);
+        }
+
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
         if ($years !== 0 || $months !== 0) {

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -736,27 +736,35 @@ final class IntlCalendarBridge implements CalendarProtocol
                 $calYear++;
             }
 
-            // Resolve new date with day constraining.
-            $this->setCalendarFields($calYear, $calMonth, $originalCalDay);
+            // Resolve new date with day constraining. When maxCalDayCache
+            // already knows the month's max, we can clamp in advance and avoid
+            // the "set original day, discover overflow, reset to max" double
+            // setCalendarFields dance.
             $maxKey = ($calYear * 32) + $calMonth;
             if (array_key_exists($maxKey, $this->maxCalDayCache)) {
                 $newMaxDay = $this->maxCalDayCache[$maxKey];
+                if ($overflow === 'reject' && $originalCalDay > $newMaxDay) {
+                    throw new InvalidArgumentException(
+                        "Day {$originalCalDay} exceeds maximum {$newMaxDay} for the resulting calendar month.",
+                    );
+                }
+                $finalCalDay = $originalCalDay > $newMaxDay ? $newMaxDay : $originalCalDay;
+                $this->setCalendarFields($calYear, $calMonth, $finalCalDay);
             } else {
+                $this->setCalendarFields($calYear, $calMonth, $originalCalDay);
                 $newMaxDay = $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_MONTH);
                 if (count($this->maxCalDayCache) >= self::FIELD_CACHE_CAP) {
                     $this->maxCalDayCache = [];
                 }
                 $this->maxCalDayCache[$maxKey] = $newMaxDay;
-            }
-
-            if ($overflow === 'reject' && $originalCalDay > $newMaxDay) {
-                throw new InvalidArgumentException(
-                    "Day {$originalCalDay} exceeds maximum {$newMaxDay} for the resulting calendar month.",
-                );
-            }
-
-            if ($originalCalDay > $newMaxDay) {
-                $this->setCalendarFields($calYear, $calMonth, $newMaxDay);
+                if ($overflow === 'reject' && $originalCalDay > $newMaxDay) {
+                    throw new InvalidArgumentException(
+                        "Day {$originalCalDay} exceeds maximum {$newMaxDay} for the resulting calendar month.",
+                    );
+                }
+                if ($originalCalDay > $newMaxDay) {
+                    $this->setCalendarFields($calYear, $calMonth, $newMaxDay);
+                }
             }
             // State was set by setCalendarFields; trailing getTime reads that.
             $epochMs = $this->intlCal->getTime();

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -625,32 +625,38 @@ final class IntlCalendarBridge implements CalendarProtocol
         int $days,
         string $overflow,
     ): array {
-        // Gregory fast path: the bare Gregorian IntlCalendar is forced proleptic
-        // in the constructor (setGregorianChange(PHP_FLOAT_MIN)), so calYear ==
-        // isoYear, calMonth == isoMonth, calDay == isoDay. Skip every intlCal
-        // round-trip in the year/month branch. Japanese/buddhist/roc retain
-        // ICU's 1582 Julian cutover, so they stay on the ICU path below.
-        if ($this->calendarId === 'gregory') {
-            $calYear = $isoYear + $years;
+        // Gregorian-based fast path: skip every intlCal round-trip when both
+        // the input and the resulting ISO year are >= 1583 (past the 1582
+        // Julian cutover that japanese/buddhist/roc still honor in ICU). For
+        // bare 'gregory' the cutover was disabled in the constructor, so the
+        // fast path always applies. Within this window the calendar fields
+        // equal the ISO fields, daysInMonth is pure ISO math, and monthsInYear
+        // is 12.
+        if ($this->isGregorianBased) {
+            $finalIsoYear = $isoYear + $years;
             $calMonth = $isoMonth + $months;
             while ($calMonth < 1) {
-                $calYear--;
+                $finalIsoYear--;
                 $calMonth += 12;
             }
             while ($calMonth > 12) {
                 $calMonth -= 12;
-                $calYear++;
+                $finalIsoYear++;
             }
-            /** @var int<1, 12> $calMonth */
-            $newMaxDay = CalendarMath::calcDaysInMonth($calYear, $calMonth);
-            if ($overflow === 'reject' && $isoDay > $newMaxDay) {
-                throw new InvalidArgumentException(
-                    "Day {$isoDay} exceeds maximum {$newMaxDay} for the resulting calendar month.",
-                );
+            $cutoverSafe = $this->calendarId === 'gregory'
+                || ($isoYear >= 1583 && $finalIsoYear >= 1583);
+            if ($cutoverSafe) {
+                /** @var int<1, 12> $calMonth */
+                $newMaxDay = CalendarMath::calcDaysInMonth($finalIsoYear, $calMonth);
+                if ($overflow === 'reject' && $isoDay > $newMaxDay) {
+                    throw new InvalidArgumentException(
+                        "Day {$isoDay} exceeds maximum {$newMaxDay} for the resulting calendar month.",
+                    );
+                }
+                $finalDay = $isoDay > $newMaxDay ? $newMaxDay : $isoDay;
+                $jdn = CalendarMath::toJulianDay($finalIsoYear, $calMonth, $finalDay) + ($weeks * 7) + $days;
+                return CalendarMath::fromJulianDay($jdn);
             }
-            $finalDay = $isoDay > $newMaxDay ? $newMaxDay : $isoDay;
-            $jdn = CalendarMath::toJulianDay($calYear, $calMonth, $finalDay) + ($weeks * 7) + $days;
-            return CalendarMath::fromJulianDay($jdn);
         }
 
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -601,12 +601,20 @@ final class IntlCalendarBridge implements CalendarProtocol
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
         if ($years !== 0 || $months !== 0) {
-            // Capture the original calendar day before year/month addition, for 'reject' overflow.
-            $originalCalDay = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
-            // Use field-level arithmetic: read calendar fields, add to year/month,
-            // then resolve back. This avoids Julian cutover issues in ICU.
-            $calYear = $this->calendarYear();
-            $calMonth = $this->calendarMonth();
+            // Capture the original calendar day and year/month. Use field-level
+            // arithmetic: read calendar fields, add to year/month, resolve back.
+            // This avoids Julian cutover issues in ICU for the gregorian path
+            // (japanese/buddhist/roc retain ICU's 1582 cutover; only the bare
+            // gregorian IntlCalendar was made proleptic in the constructor).
+            if ($this->isGregorianBased) {
+                $originalCalDay = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
+                $calYear = $this->calendarYear();
+                $calMonth = $this->calendarMonth();
+            } else {
+                $originalCalDay = $this->day($isoYear, $isoMonth, $isoDay);
+                $calYear = $this->year($isoYear, $isoMonth, $isoDay);
+                $calMonth = $this->month($isoYear, $isoMonth, $isoDay);
+            }
 
             // For calendars with leap months, year addition must preserve monthCode
             // (not ordinal position), because leap months shift ordinals between years.

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -56,6 +56,12 @@ final class IntlCalendarBridge implements CalendarProtocol
     private readonly bool $isGregorianBased;
     /** Calendars with 13 months (coptic/ethiopic family). */
     private readonly bool $isCopticLike;
+    /**
+     * Calendars where ICU's getActualMaximum() returns stale values after
+     * setTime() unless the internal fields are explicitly resolved. Applies
+     * to chinese/dangi leap-month handling.
+     */
+    private readonly bool $needsForcedFieldResolution;
 
     /** @var array<int, int> Memoized findChineseLeapMonthInYear results, keyed by calYear. */
     private array $chineseLeapMonthCache = [];
@@ -88,6 +94,10 @@ final class IntlCalendarBridge implements CalendarProtocol
         };
         $this->isCopticLike = match ($calendarId) {
             'coptic', 'ethiopic', 'ethioaa' => true,
+            default => false,
+        };
+        $this->needsForcedFieldResolution = match ($calendarId) {
+            'chinese', 'dangi' => true,
             default => false,
         };
     }
@@ -1460,17 +1470,13 @@ final class IntlCalendarBridge implements CalendarProtocol
             return;
         }
         $jdn = CalendarMath::toJulianDay($isoYear, $isoMonth, $isoDay);
-        if ($this->lastSetJdn === $jdn) {
-            $this->lastSetIsoYear = $isoYear;
-            $this->lastSetIsoMonth = $isoMonth;
-            $this->lastSetIsoDay = $isoDay;
-            return;
-        }
         $epochMs = ($jdn - 2_440_588) * self::MS_PER_DAY;
         $this->intlCal->setTime((float) $epochMs);
-        // Force ICU internal field resolution. Without this, getActualMaximum()
-        // may return stale values for Chinese/Dangi leap months.
-        $_ = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
+        if ($this->needsForcedFieldResolution) {
+            // Without this, getActualMaximum() may return stale values for
+            // Chinese/Dangi leap months.
+            $_ = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
+        }
         $this->lastSetJdn = $jdn;
         $this->lastSetIsoYear = $isoYear;
         $this->lastSetIsoMonth = $isoMonth;

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -68,34 +68,37 @@ final class IntlCalendarBridge implements CalendarProtocol
 
     /**
      * Per-iso-date caches for pure-function calendar projections. Keyed by
-     * "isoYear:isoMonth:isoDay". Capped to bound memory in long-running
-     * processes; capped arrays are cleared when they exceed the threshold.
+     * packed int (isoYear * 512) + (isoMonth * 32) + isoDay — same layout as
+     * {@see CalendarMath::toJulianDay()}, avoids string formatting per lookup.
+     * Capped to bound memory in long-running processes; capped arrays are
+     * cleared when they exceed the threshold.
      *
-     * @var array<string, int>
+     * @var array<int, int>
      */
     private array $yearCache = [];
-    /** @var array<string, int> */
+    /** @var array<int, int> */
     private array $monthCache = [];
-    /** @var array<string, int> */
+    /** @var array<int, int> */
     private array $dayCache = [];
-    /** @var array<string, string> */
+    /** @var array<int, string> */
     private array $monthCodeCache = [];
-    /** @var array<string, int> */
+    /** @var array<int, int> */
     private array $dayOfYearCache = [];
-    /** @var array<string, int> */
+    /** @var array<int, int> */
     private array $daysInMonthCache = [];
-    /** @var array<string, int> */
+    /** @var array<int, int> */
     private array $daysInYearCache = [];
-    /** @var array<string, int> */
+    /** @var array<int, int> */
     private array $monthsInYearCache = [];
-    /** @var array<string, bool> */
+    /** @var array<int, bool> */
     private array $inLeapYearCache = [];
     /**
-     * Max day of the calendar month, keyed by "calYear:calMonth". Populated
-     * opportunistically from ICU after setCalendarFields; depends only on the
-     * calendar year/month (calendar day doesn't shift the maximum).
+     * Max day of the calendar month, keyed by packed int (calYear * 32) +
+     * calMonth. Populated opportunistically from ICU after setCalendarFields;
+     * depends only on the calendar year/month (calendar day doesn't shift the
+     * maximum).
      *
-     * @var array<string, int>
+     * @var array<int, int>
      */
     private array $maxCalDayCache = [];
     /**
@@ -198,7 +201,7 @@ final class IntlCalendarBridge implements CalendarProtocol
 
     private function yearFromIcu(int $isoYear, int $isoMonth, int $isoDay): int
     {
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->yearCache)) {
             return $this->yearCache[$key];
         }
@@ -223,7 +226,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return $isoMonth;
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->monthCache)) {
             return $this->monthCache[$key];
         }
@@ -247,7 +250,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return $isoDay;
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->dayCache)) {
             return $this->dayCache[$key];
         }
@@ -335,7 +338,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return sprintf('M%02d', $isoMonth);
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->monthCodeCache)) {
             return $this->monthCodeCache[$key];
         }
@@ -359,7 +362,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::isoDayOfYear($isoYear, $isoMonth, $isoDay);
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->dayOfYearCache)) {
             return $this->dayOfYearCache[$key];
         }
@@ -379,7 +382,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::calcDaysInMonth($isoYear, $isoMonth);
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->daysInMonthCache)) {
             return $this->daysInMonthCache[$key];
         }
@@ -399,7 +402,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::isLeapYear($isoYear) ? 366 : 365;
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->daysInYearCache)) {
             return $this->daysInYearCache[$key];
         }
@@ -431,7 +434,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return 12;
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->monthsInYearCache)) {
             return $this->monthsInYearCache[$key];
         }
@@ -455,7 +458,7 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::isLeapYear($isoYear);
         }
-        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        $key = ($isoYear * 512) + ($isoMonth * 32) + $isoDay;
         if (array_key_exists($key, $this->inLeapYearCache)) {
             return $this->inLeapYearCache[$key];
         }
@@ -688,7 +691,7 @@ final class IntlCalendarBridge implements CalendarProtocol
 
             // Resolve new date with day constraining.
             $this->setCalendarFields($calYear, $calMonth, $originalCalDay);
-            $maxKey = "{$calYear}:{$calMonth}";
+            $maxKey = ($calYear * 32) + $calMonth;
             if (array_key_exists($maxKey, $this->maxCalDayCache)) {
                 $newMaxDay = $this->maxCalDayCache[$maxKey];
             } else {

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -90,6 +90,14 @@ final class IntlCalendarBridge implements CalendarProtocol
     private array $monthsInYearCache = [];
     /** @var array<string, bool> */
     private array $inLeapYearCache = [];
+    /**
+     * Max day of the calendar month, keyed by "calYear:calMonth". Populated
+     * opportunistically from ICU after setCalendarFields; depends only on the
+     * calendar year/month (calendar day doesn't shift the maximum).
+     *
+     * @var array<string, int>
+     */
+    private array $maxCalDayCache = [];
 
     private const FIELD_CACHE_CAP = 1024;
 
@@ -648,7 +656,16 @@ final class IntlCalendarBridge implements CalendarProtocol
 
             // Resolve new date with day constraining.
             $this->setCalendarFields($calYear, $calMonth, $originalCalDay);
-            $newMaxDay = $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_MONTH);
+            $maxKey = "{$calYear}:{$calMonth}";
+            if (array_key_exists($maxKey, $this->maxCalDayCache)) {
+                $newMaxDay = $this->maxCalDayCache[$maxKey];
+            } else {
+                $newMaxDay = $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_MONTH);
+                if (count($this->maxCalDayCache) >= self::FIELD_CACHE_CAP) {
+                    $this->maxCalDayCache = [];
+                }
+                $this->maxCalDayCache[$maxKey] = $newMaxDay;
+            }
 
             if ($overflow === 'reject' && $originalCalDay > $newMaxDay) {
                 throw new InvalidArgumentException(

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -98,6 +98,14 @@ final class IntlCalendarBridge implements CalendarProtocol
      * @var array<string, int>
      */
     private array $maxCalDayCache = [];
+    /**
+     * Memoized calendarToIsoFromMonthCode successes, keyed by
+     * "calYear:monthCode:calDay:overflow". Only successful returns are cached;
+     * exception paths re-run the computation.
+     *
+     * @var array<string, array{0: int, 1: int<1, 12>, 2: int<1, 31>}>
+     */
+    private array $calendarToIsoFromMonthCodeCache = [];
 
     private const FIELD_CACHE_CAP = 1024;
 
@@ -518,6 +526,22 @@ final class IntlCalendarBridge implements CalendarProtocol
 
     #[\Override]
     public function calendarToIsoFromMonthCode(int $calYear, string $monthCode, int $calDay, string $overflow): array
+    {
+        $cacheKey = "{$calYear}:{$monthCode}:{$calDay}:{$overflow}";
+        if (array_key_exists($cacheKey, $this->calendarToIsoFromMonthCodeCache)) {
+            return $this->calendarToIsoFromMonthCodeCache[$cacheKey];
+        }
+        $result = $this->calendarToIsoFromMonthCodeUncached($calYear, $monthCode, $calDay, $overflow);
+        if (count($this->calendarToIsoFromMonthCodeCache) >= self::FIELD_CACHE_CAP) {
+            $this->calendarToIsoFromMonthCodeCache = [];
+        }
+        return $this->calendarToIsoFromMonthCodeCache[$cacheKey] = $result;
+    }
+
+    /**
+     * @return array{0: int, 1: int<1, 12>, 2: int<1, 31>}
+     */
+    private function calendarToIsoFromMonthCodeUncached(int $calYear, string $monthCode, int $calDay, string $overflow): array
     {
         $isLeapCode = str_ends_with($monthCode, 'L');
 

--- a/src/Spec/Internal/Calendar/IntlCalendarBridge.php
+++ b/src/Spec/Internal/Calendar/IntlCalendarBridge.php
@@ -66,6 +66,33 @@ final class IntlCalendarBridge implements CalendarProtocol
     /** @var array<int, int> Memoized findChineseLeapMonthInYear results, keyed by calYear. */
     private array $chineseLeapMonthCache = [];
 
+    /**
+     * Per-iso-date caches for pure-function calendar projections. Keyed by
+     * "isoYear:isoMonth:isoDay". Capped to bound memory in long-running
+     * processes; capped arrays are cleared when they exceed the threshold.
+     *
+     * @var array<string, int>
+     */
+    private array $yearCache = [];
+    /** @var array<string, int> */
+    private array $monthCache = [];
+    /** @var array<string, int> */
+    private array $dayCache = [];
+    /** @var array<string, string> */
+    private array $monthCodeCache = [];
+    /** @var array<string, int> */
+    private array $dayOfYearCache = [];
+    /** @var array<string, int> */
+    private array $daysInMonthCache = [];
+    /** @var array<string, int> */
+    private array $daysInYearCache = [];
+    /** @var array<string, int> */
+    private array $monthsInYearCache = [];
+    /** @var array<string, bool> */
+    private array $inLeapYearCache = [];
+
+    private const FIELD_CACHE_CAP = 1024;
+
     /** JDN that $intlCal was last set to via setIsoDate, or null if set via another path. */
     private ?int $lastSetJdn = null;
 
@@ -155,19 +182,22 @@ final class IntlCalendarBridge implements CalendarProtocol
 
     private function yearFromIcu(int $isoYear, int $isoMonth, int $isoDay): int
     {
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->yearCache)) {
+            return $this->yearCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        if (in_array($this->calendarId, ['coptic', 'ethiopic'], strict: true)) {
-            return $this->intlCal->get(self::FIELD_EXTENDED_YEAR);
+        $v = match (true) {
+            $this->calendarId === 'coptic', $this->calendarId === 'ethiopic' => $this->intlCal->get(self::FIELD_EXTENDED_YEAR),
+            $this->calendarId === 'chinese' => $this->intlCal->get(self::FIELD_EXTENDED_YEAR) - self::CHINESE_YEAR_OFFSET,
+            $this->calendarId === 'dangi' => $this->intlCal->get(self::FIELD_EXTENDED_YEAR) - self::DANGI_YEAR_OFFSET,
+            default => $this->intlCal->get(\IntlCalendar::FIELD_YEAR),
+        };
+        if (count($this->yearCache) >= self::FIELD_CACHE_CAP) {
+            $this->yearCache = [];
         }
-        if ($this->calendarId === 'chinese') {
-            return $this->intlCal->get(self::FIELD_EXTENDED_YEAR) - self::CHINESE_YEAR_OFFSET;
-        }
-        if ($this->calendarId === 'dangi') {
-            return $this->intlCal->get(self::FIELD_EXTENDED_YEAR) - self::DANGI_YEAR_OFFSET;
-        }
-
-        return $this->intlCal->get(\IntlCalendar::FIELD_YEAR);
+        return $this->yearCache[$key] = $v;
     }
 
     #[\Override]
@@ -177,14 +207,21 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return $isoMonth;
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->monthCache)) {
+            return $this->monthCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        return match ($this->calendarId) {
+        $v = match ($this->calendarId) {
             'hebrew' => $this->hebrewMonthOrdinal(),
             'chinese', 'dangi' => $this->chineseMonthOrdinal(),
             default => $this->intlCal->get(\IntlCalendar::FIELD_MONTH) + 1,
         };
+        if (count($this->monthCache) >= self::FIELD_CACHE_CAP) {
+            $this->monthCache = [];
+        }
+        return $this->monthCache[$key] = $v;
     }
 
     #[\Override]
@@ -194,32 +231,49 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return $isoDay;
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->dayCache)) {
+            return $this->dayCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        return $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
+        $v = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_MONTH);
+        if (count($this->dayCache) >= self::FIELD_CACHE_CAP) {
+            $this->dayCache = [];
+        }
+        return $this->dayCache[$key] = $v;
     }
 
     #[\Override]
     public function era(int $isoYear, int $isoMonth, int $isoDay): ?string
     {
-        return match ($this->calendarId) {
+        // Constant-era calendars: no ICU state needed.
+        $constant = match ($this->calendarId) {
             'gregory' => $isoYear >= 1 ? 'ce' : 'bce',
-            'japanese' => $this->japaneseEraFromIso($isoYear, $isoMonth, $isoDay),
             'buddhist' => 'be',
             'roc' => $isoYear >= 1912 ? 'roc' : 'broc',
-            'coptic' => 'am',
-            'ethiopic' => $this->intlCal->get(\IntlCalendar::FIELD_ERA) === 1 ? 'am' : 'aa',
+            'coptic', 'hebrew' => 'am',
             'ethioaa' => 'aa',
-            'hebrew' => 'am',
             'indian' => 'shaka',
+            'persian' => 'ap',
+            default => '__icu__',
+        };
+        if ($constant !== '__icu__') {
+            return $constant;
+        }
+        if ($this->calendarId === 'japanese') {
+            return $this->japaneseEraFromIso($isoYear, $isoMonth, $isoDay);
+        }
+        // Calendars whose era depends on the date: ensure ICU state is fresh.
+        $this->setIsoDate($isoYear, $isoMonth, $isoDay);
+        return match ($this->calendarId) {
+            'ethiopic' => $this->intlCal->get(\IntlCalendar::FIELD_ERA) === 1 ? 'am' : 'aa',
             'islamic',
             'islamic-civil',
             'islamic-rgsa',
             'islamic-tbla',
             'islamic-umalqura',
                 => $this->intlCal->get(\IntlCalendar::FIELD_YEAR) >= 1 ? 'ah' : 'bh',
-            'persian' => 'ap',
             default => null,
         };
     }
@@ -265,14 +319,21 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return sprintf('M%02d', $isoMonth);
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->monthCodeCache)) {
+            return $this->monthCodeCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        return match ($this->calendarId) {
+        $v = match ($this->calendarId) {
             'hebrew' => $this->hebrewMonthCode(),
             'chinese', 'dangi' => $this->chineseMonthCode(),
             default => sprintf('M%02d', $this->intlCal->get(\IntlCalendar::FIELD_MONTH) + 1),
         };
+        if (count($this->monthCodeCache) >= self::FIELD_CACHE_CAP) {
+            $this->monthCodeCache = [];
+        }
+        return $this->monthCodeCache[$key] = $v;
     }
 
     #[\Override]
@@ -282,10 +343,17 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::isoDayOfYear($isoYear, $isoMonth, $isoDay);
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->dayOfYearCache)) {
+            return $this->dayOfYearCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        return $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_YEAR);
+        $v = $this->intlCal->get(\IntlCalendar::FIELD_DAY_OF_YEAR);
+        if (count($this->dayOfYearCache) >= self::FIELD_CACHE_CAP) {
+            $this->dayOfYearCache = [];
+        }
+        return $this->dayOfYearCache[$key] = $v;
     }
 
     #[\Override]
@@ -295,10 +363,17 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::calcDaysInMonth($isoYear, $isoMonth);
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->daysInMonthCache)) {
+            return $this->daysInMonthCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        return $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_MONTH);
+        $v = $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_MONTH);
+        if (count($this->daysInMonthCache) >= self::FIELD_CACHE_CAP) {
+            $this->daysInMonthCache = [];
+        }
+        return $this->daysInMonthCache[$key] = $v;
     }
 
     #[\Override]
@@ -308,18 +383,29 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::isLeapYear($isoYear) ? 366 : 365;
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->daysInYearCache)) {
+            return $this->daysInYearCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
         // Apply ICU 76.1 correction for known Chinese calendar discrepancies.
         if ($this->calendarId === 'chinese') {
             $calYear = $this->intlCal->get(self::FIELD_EXTENDED_YEAR) - self::CHINESE_YEAR_OFFSET;
             if (array_key_exists($calYear, self::CHINESE_DAYS_IN_YEAR_CORRECTIONS)) {
-                return self::CHINESE_DAYS_IN_YEAR_CORRECTIONS[$calYear];
+                $v = self::CHINESE_DAYS_IN_YEAR_CORRECTIONS[$calYear];
+                if (count($this->daysInYearCache) >= self::FIELD_CACHE_CAP) {
+                    $this->daysInYearCache = [];
+                }
+                return $this->daysInYearCache[$key] = $v;
             }
         }
 
-        return $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_YEAR);
+        $v = $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_YEAR);
+        if (count($this->daysInYearCache) >= self::FIELD_CACHE_CAP) {
+            $this->daysInYearCache = [];
+        }
+        return $this->daysInYearCache[$key] = $v;
     }
 
     #[\Override]
@@ -329,14 +415,21 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return 12;
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->monthsInYearCache)) {
+            return $this->monthsInYearCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        return match ($this->calendarId) {
+        $v = match ($this->calendarId) {
             'hebrew' => $this->isHebrewLeapYear() ? 13 : 12,
             'chinese', 'dangi' => $this->hasChineseLeapMonth() ? 13 : 12,
             default => $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_MONTH) + 1,
         };
+        if (count($this->monthsInYearCache) >= self::FIELD_CACHE_CAP) {
+            $this->monthsInYearCache = [];
+        }
+        return $this->monthsInYearCache[$key] = $v;
     }
 
     #[\Override]
@@ -346,16 +439,23 @@ final class IntlCalendarBridge implements CalendarProtocol
         if ($this->isGregorianBased) {
             return CalendarMath::isLeapYear($isoYear);
         }
-
+        $key = "{$isoYear}:{$isoMonth}:{$isoDay}";
+        if (array_key_exists($key, $this->inLeapYearCache)) {
+            return $this->inLeapYearCache[$key];
+        }
         $this->setIsoDate($isoYear, $isoMonth, $isoDay);
 
-        return match ($this->calendarId) {
+        $v = match ($this->calendarId) {
             'hebrew' => $this->isHebrewLeapYear(),
             'chinese', 'dangi' => $this->hasChineseLeapMonth(),
             'coptic', 'ethiopic', 'ethioaa' => $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_YEAR) > 365,
             'persian' => $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_YEAR) > 365,
             default => $this->intlCal->getActualMaximum(\IntlCalendar::FIELD_DAY_OF_YEAR) > 354, // Islamic variants: leap year has 355 days, non-leap 354
         };
+        if (count($this->inLeapYearCache) >= self::FIELD_CACHE_CAP) {
+            $this->inLeapYearCache = [];
+        }
+        return $this->inLeapYearCache[$key] = $v;
     }
 
     // -------------------------------------------------------------------------

--- a/src/Spec/Internal/Calendar/PureHebrewCalendar.php
+++ b/src/Spec/Internal/Calendar/PureHebrewCalendar.php
@@ -42,6 +42,9 @@ final class PureHebrewCalendar implements CalendarProtocol
     /** @var array<int, array{0: int, 1: int, 2: int}> Memoized isoToHebrew results, keyed by JDN. */
     private static array $isoToHebrewCache = [];
 
+    /** @var array<int, int> Memoized monthLength results, keyed by (year * 16) + ordinalMonth. */
+    private static array $monthLengthCache = [];
+
     #[\Override]
     public function id(): string
     {
@@ -148,6 +151,10 @@ final class PureHebrewCalendar implements CalendarProtocol
      */
     private static function monthLength(int $year, int $ordinalMonth): int
     {
+        $key = ($year * 16) + $ordinalMonth;
+        if (array_key_exists($key, self::$monthLengthCache)) {
+            return self::$monthLengthCache[$key];
+        }
         $type = self::yearType($year);
         $isLeap = self::isLeapYear($year);
         $totalMonths = $isLeap ? 13 : 12;
@@ -158,7 +165,7 @@ final class PureHebrewCalendar implements CalendarProtocol
 
         // Map ordinal to logical month identity
         if ($isLeap) {
-            return match ($ordinalMonth) {
+            $v = match ($ordinalMonth) {
                 1 => 30, // Tishrei
                 2 => $type === 'complete' ? 30 : 29, // Cheshvan
                 3 => $type === 'deficient' ? 29 : 30, // Kislev
@@ -174,9 +181,10 @@ final class PureHebrewCalendar implements CalendarProtocol
                 // Elul (ordinal 13) and any value beyond the validated range.
                 default => 29,
             };
+            return self::$monthLengthCache[$key] = $v;
         }
 
-        return match ($ordinalMonth) {
+        $v = match ($ordinalMonth) {
             1 => 30, // Tishrei
             2 => $type === 'complete' ? 30 : 29, // Cheshvan
             3 => $type === 'deficient' ? 29 : 30, // Kislev
@@ -193,6 +201,7 @@ final class PureHebrewCalendar implements CalendarProtocol
                 "Invalid ordinal month {$ordinalMonth} for non-leap Hebrew year.",
             ),
         };
+        return self::$monthLengthCache[$key] = $v;
     }
 
     /**

--- a/src/Spec/Internal/CalendarMath.php
+++ b/src/Spec/Internal/CalendarMath.php
@@ -809,6 +809,9 @@ final class CalendarMath
     /** @var array<int, int> Memoized toJulianDay results, keyed by encoded (year, month, day). */
     private static array $toJulianDayCache = [];
 
+    /** @var array<int, array{0: int, 1: int<1, 12>, 2: int<1, 31>}> Memoized fromJulianDay results, keyed by JDN. */
+    private static array $fromJulianDayCache = [];
+
     /**
      * Converts a proleptic Gregorian calendar date to a Julian Day Number.
      * Algorithm: Richards (2013).
@@ -850,6 +853,9 @@ final class CalendarMath
      */
     public static function fromJulianDay(int $jdn): array
     {
+        if (array_key_exists($jdn, self::$fromJulianDayCache)) {
+            return self::$fromJulianDayCache[$jdn];
+        }
         $a = $jdn + 32_044;
 
         // Inline floorDiv: for $a ≥ 0 (jdn ≥ -32044, covers all realistic dates),
@@ -875,7 +881,7 @@ final class CalendarMath
         $month = $m + 3 - (12 * $mDiv10);
         $year = (100 * $b) + $d - 4800 + $mDiv10;
 
-        return [$year, $month, $day];
+        return self::$fromJulianDayCache[$jdn] = [$year, $month, $day];
     }
 
     /**

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -2168,20 +2168,20 @@ final class ZonedDateTime implements Stringable
         $offsetSec = $this->resolveOffsetSecondsAt($epochSec);
         $localSec = $epochSec + $offsetSec;
 
-        // Create a UTC DateTimeImmutable at local seconds to extract Y/m/d H:i:s.
-        $dt = new \DateTimeImmutable(sprintf('@%d', $localSec));
-
-        $year = (int) $dt->format('Y');
-        /** @var int<1, 12> format('n') always returns 1–12 */
-        $month = (int) $dt->format('n');
-        /** @var int<1, 31> format('j') always returns 1–31 */
-        $day = (int) $dt->format('j');
-        /** @var int<0, 23> format('G') always returns 0–23 */
-        $hour = (int) $dt->format('G');
-        /** @var int<0, 59> format('i') always returns 00–59 */
-        $minute = (int) $dt->format('i');
-        /** @var int<0, 59> format('s') always returns 00–59 */
-        $second = (int) $dt->format('s');
+        // Split seconds-since-epoch into whole days + remainder, floor-divided
+        // so negative local seconds produce the correct pre-1970 date. The JDN
+        // roundtrip hits CalendarMath's cached fromJulianDay — cheaper than a
+        // DateTimeImmutable + 6 format() calls.
+        $localDay = CalendarMath::floorDiv($localSec, 86_400);
+        $timeOfDaySec = $localSec - ($localDay * 86_400);
+        [$year, $month, $day] = CalendarMath::fromJulianDay($localDay + 2_440_588);
+        /** @var int<0, 23> $hour */
+        $hour = intdiv(num1: $timeOfDaySec, num2: 3600);
+        $rem = $timeOfDaySec - ($hour * 3600);
+        /** @var int<0, 59> $minute */
+        $minute = intdiv(num1: $rem, num2: 60);
+        /** @var int<0, 59> $second */
+        $second = $rem - ($minute * 60);
 
         /** @var int<0, 999> $ms — $subNs < 10^9, dividing by 10^6 gives 0–999 */
         $ms = intdiv(num1: $subNs, num2: self::NS_PER_MILLISECOND);

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -789,6 +789,16 @@ final class ZonedDateTime implements Stringable
      */
     private static function canonicalizeTimezoneForComparison(string $id): string
     {
+        /** @var array<string, string> $cache */
+        static $cache = [];
+        if (array_key_exists($id, $cache)) {
+            return $cache[$id];
+        }
+        return $cache[$id] = self::canonicalizeTimezoneForComparisonUncached($id);
+    }
+
+    private static function canonicalizeTimezoneForComparisonUncached(string $id): string
+    {
         // UTC aliases all compare equal.
         /** @var list<string> $utcAliases */
         static $utcAliases = [
@@ -1935,6 +1945,22 @@ final class ZonedDateTime implements Stringable
      */
     public static function normalizeTimezoneId(string $id, bool $rejectDatetimeStrings = false): string
     {
+        /** @var array<string, string> $cache */
+        static $cache = [];
+        $cacheKey = ($rejectDatetimeStrings ? "R\0" : "N\0") . $id;
+        if (array_key_exists($cacheKey, $cache)) {
+            return $cache[$cacheKey];
+        }
+        $result = self::normalizeTimezoneIdUncached($id, $rejectDatetimeStrings);
+        if (count($cache) >= 1024) {
+            $cache = [];
+        }
+        $cache[$cacheKey] = $result;
+        return $result;
+    }
+
+    private static function normalizeTimezoneIdUncached(string $id, bool $rejectDatetimeStrings): string
+    {
         if ($id === '') {
             throw new InvalidArgumentException('ZonedDateTime timeZoneId must not be empty.');
         }
@@ -2192,6 +2218,16 @@ final class ZonedDateTime implements Stringable
      * inconsistencies where ICU and IANA disagree on canonical targets.
      */
     private static function resolveCanonicalTimezoneId(string $id): string
+    {
+        /** @var array<string, string> $cache */
+        static $cache = [];
+        if (array_key_exists($id, $cache)) {
+            return $cache[$id];
+        }
+        return $cache[$id] = self::resolveCanonicalTimezoneIdUncached($id);
+    }
+
+    private static function resolveCanonicalTimezoneIdUncached(string $id): string
     {
         // Known ICU inconsistencies where an IANA link target is reported as
         // self-canonical instead of resolving to its true primary zone.

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -1945,18 +1945,30 @@ final class ZonedDateTime implements Stringable
      */
     public static function normalizeTimezoneId(string $id, bool $rejectDatetimeStrings = false): string
     {
-        /** @var array<string, string> $cache */
-        static $cache = [];
-        $cacheKey = ($rejectDatetimeStrings ? "R\0" : "N\0") . $id;
-        if (array_key_exists($cacheKey, $cache)) {
-            return $cache[$cacheKey];
+        // Split caches per flag so the hot path skips the "R\0"/"N\0" prefix
+        // concat that the single-cache variant used to build the lookup key.
+        /** @var array<string, string> $cacheR */
+        static $cacheR = [];
+        /** @var array<string, string> $cacheN */
+        static $cacheN = [];
+        if ($rejectDatetimeStrings) {
+            if (array_key_exists($id, $cacheR)) {
+                return $cacheR[$id];
+            }
+            $result = self::normalizeTimezoneIdUncached($id, true);
+            if (count($cacheR) >= 1024) {
+                $cacheR = [];
+            }
+            return $cacheR[$id] = $result;
         }
-        $result = self::normalizeTimezoneIdUncached($id, $rejectDatetimeStrings);
-        if (count($cache) >= 1024) {
-            $cache = [];
+        if (array_key_exists($id, $cacheN)) {
+            return $cacheN[$id];
         }
-        $cache[$cacheKey] = $result;
-        return $result;
+        $result = self::normalizeTimezoneIdUncached($id, false);
+        if (count($cacheN) >= 1024) {
+            $cacheN = [];
+        }
+        return $cacheN[$id] = $result;
     }
 
     private static function normalizeTimezoneIdUncached(string $id, bool $rejectDatetimeStrings): string

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -2286,8 +2286,14 @@ final class ZonedDateTime implements Stringable
             return $sign * (((int) $m[2] * 3600) + ((int) $m[3] * 60));
         }
         // IANA timezone: use PHP to find the offset at the given instant.
-        /** @psalm-suppress ArgumentTypeCoercion — timeZoneId is validated to be non-empty in constructor */
-        $tz = new \DateTimeZone($this->resolvedTimeZoneId);
+        /** @var array<string, \DateTimeZone> $tzCache */
+        static $tzCache = [];
+        $tz = $tzCache[$this->resolvedTimeZoneId] ?? null;
+        if ($tz === null) {
+            /** @psalm-suppress ArgumentTypeCoercion — timeZoneId is validated to be non-empty in constructor */
+            $tz = new \DateTimeZone($this->resolvedTimeZoneId);
+            $tzCache[$this->resolvedTimeZoneId] = $tz;
+        }
         return $tz->getOffset(new \DateTimeImmutable(sprintf('@%d', $epochSec)));
     }
 


### PR DESCRIPTION
## Summary

Reduces per-call ICU and pure-math overhead across the Temporal calendar stack by adding targeted memoization and analytical fast paths to hot paths surfaced by Xdebug profiling of the Test262 suite.

**Test262 wall time is ~42% faster than master** (7-run median on the dev container: master 16.785s → branch 9.731s).

## Commits and measured impact

Impact is reported as each commit's percentage improvement relative to the immediately preceding state.

| # | Commit | Impact |
|---|---|---|
| 1 | Memoize `ZonedDateTime` timezone canonicalization | ~6.1% faster |
| 2 | Gate ICU forced field resolution to chinese/dangi + dead-code cleanup | cleanup, no measurable delta |
| 3 | Memoize `IntlCalendarBridge` iso→calendar field projections | ~9.8% faster |
| 4 | Cache `getActualMaximum(DAY_OF_MONTH)` by `(calYear, calMonth)` in `dateAdd` | ~13.5% faster |
| 5 | Memoize `CalendarMath::fromJulianDay` | ~2.3% faster |
| 6 | Route `trialDateAddDoesNotSurpass` through cached field getters | ~5.7% faster |
| 7 | Route non-gregorian `dateAdd` reads through cached field getters | ~3.0% faster |
| 8 | Cache `DateTimeZone` instances in `resolveOffsetSecondsAt` | ~3.0% faster |
| 9 | Memoize `IntlCalendarBridge::calendarToIsoFromMonthCode` | ~2.6% faster |
| 10 | Drop dead `calendarMonth()` read in `dateUntil` | cleanup, no measurable delta |
| 11 | Pack `IntlCalendarBridge` field caches into int keys | ~2.2% faster |
| 12 | Add gregory-only `dateAdd` analytical fast path | ~0.2% faster |
| 13 | Split `normalizeTimezoneId` cache by `rejectDatetimeStrings` flag | ~0.1% faster |
| 14 | Extend `dateAdd` fast path to buddhist/roc/japanese post-1582 | ~1.5% faster |
| 15 | Gate `setIsoDate` in `dateAdd` to callers that actually read ICU state | ~6.1% faster |
| 16 | Collapse `dateAdd`'s double `setCalendarFields` on maxCalDay cache hit | ~0.3% faster |
| 17 | Swap `DateTimeImmutable` for `fromJulianDay` in `localComponents` | ~0.4% faster |
| 18 | Memoize `PureHebrewCalendar::monthLength` | ~0.5% faster |

### Detail per commit

1. **Timezone canonicalization caches.** `normalizeTimezoneId`, `resolveCanonicalTimezoneId`, and `canonicalizeTimezoneForComparison` cache by input id (~880k calls across ~400 distinct IANA IDs).
2. **ICU forced field resolution gated to chinese/dangi.** Only those need the forced `get(FIELD_DAY_OF_MONTH)` after `setTime` to avoid stale `getActualMaximum` values; skip it elsewhere. Also drops a dead-code branch in `setIsoDate`.
3. **Iso→calendar field caches.** `year`, `month`, `day`, `monthCode`, `dayOfYear`, `daysInMonth`, `daysInYear`, `monthsInYear`, `inLeapYear` each cache by iso tuple. Also fixes a latent `era()` bug that had been depending on implicit ICU state from prior calls.
4. **`(calYear, calMonth)` max-day cache in `dateAdd`.** Eliminates ~140k redundant ICU calls in the hot loop since the max day of a calendar month doesn't shift with the calendar day.
5. **`fromJulianDay` memoization.** Pure function of JDN, called 254k times in the suite. Matches the existing memoization pattern used by its companion `toJulianDay`.
6. **`trialDateAddDoesNotSurpass` routed through cached getters.** Replaces inline `setIsoDate` + `intlCal->get(FIELD_DAY_OF_MONTH)` pairs with the now-cached `day()` / `month()` methods, cutting repeated ICU reads in the `dateUntil` trial loop.
7. **`dateAdd` non-gregorian reads routed through cached getters.** Same idea at the `dateAdd` entrypoint, guarded to non-gregorian calendars because japanese/buddhist/roc still honour ICU's 1582 Julian cutover.
8. **`DateTimeZone` cache in `resolveOffsetSecondsAt`.** The method previously built a fresh `DateTimeZone` per `localComponents` call for IANA zones; the object is stateless w.r.t. the instant so sharing is safe. Cache is naturally bounded by the IANA zone set.
9. **`calendarToIsoFromMonthCode` memoization.** The `(calYear, monthCode, calDay, overflow)` resolution is effectively pure (callers don't depend on the incidental ICU state it leaves behind), so caching successful returns eliminates repeated leap-month validation work for chinese/dangi/hebrew PlainMonthDay resolution loops.
10. **Dead `calendarMonth()` read.** `IntlCalendarBridge::dateUntil` had a leftover `$this->calendarMonth()` line whose return value was discarded; the method has no side effects.
11. **Int-keyed field caches.** Every `IntlCalendarBridge` cache that used `"isoYear:isoMonth:isoDay"` strings now keys on the packed int `(isoYear * 512) + (isoMonth * 32) + isoDay`, matching `CalendarMath::toJulianDay`'s existing layout. Skips string formatting on every lookup; `maxCalDayCache` gets the same treatment with `(calYear * 32) + calMonth`.
12. **Gregory-only `dateAdd` analytical fast path.** The bare gregory calendar is forced fully proleptic in the constructor, so the year/month branch of `dateAdd` can compute the final JDN directly from `CalendarMath::calcDaysInMonth` + `toJulianDay` without any ICU calls.
13. **Split `normalizeTimezoneId` cache.** The single-cache implementation built its lookup key as `"R\0" . $id` / `"N\0" . $id`, allocating a new string on every call; separate static arrays keyed by the raw timezone id skip the prefix concat on the hot cache-hit path.
14. **Extend `dateAdd` fast path to buddhist/roc/japanese post-1582.** These three share gregorian structure but retain ICU's 1582 Julian cutover. When both the input and the resulting ISO year are >= 1583 the proleptic fast path produces the same answer as the ICU round-trip; pre-1583 inputs continue through the original ICU path.
15. **Gate `setIsoDate` in `dateAdd` to callers that actually read ICU state.** The initial `setIsoDate` was wasted for most non-gregorian calendars because `setCalendarFields` later calls `intlCal->clear()` and rebuilds fields from scratch; only the chinese/dangi/hebrew year-addition branches read ICU fields before that. The `years == 0 && months == 0` tail now computes the final JDN analytically from the iso tuple instead of via `intlCal->getTime()`.
16. **Collapse double `setCalendarFields`.** On a `maxCalDayCache` hit, `dateAdd` already knows the clamped day before touching ICU — one `setCalendarFields` call suffices. The cache-miss side keeps the original "set original day, read max, reset" sequence to harvest the new max value.
17. **`fromJulianDay` in `localComponents`.** Replaces `new DateTimeImmutable(sprintf('@%d', ...))` + six `format()` calls with `floorDiv(localSec, 86400)` + `CalendarMath::fromJulianDay` + pure integer arithmetic for H/M/S.
18. **Memoize `PureHebrewCalendar::monthLength`.** 134k calls during the suite; each did a `yearType` lookup, leap-year mod chain, and match dispatch. Packed `(year * 16) + ordinal` key.

## Failed experiments (reverted on this branch)

- Unifying gregorian and non-gregorian `dateAdd` reads broke 8 era-boundary japanese tests and was reverted.
- Hoisting `origCalDay` / `origMonthCode` / `origOrd` out of `trialDateAddDoesNotSurpass` into the `dateUntil` caller produced no measurable gain; reverted to keep the simpler signature.
- A prior attempt to memoize `PureHebrewCalendar::monthLength` with a string key showed no delta and was reverted; re-introducing with a packed-int key (commit 18) produces a consistent gain.

## Cache sizing

- Per-instance, bounded (`IntlCalendarBridge`): one cache per memoized public method plus `maxCalDayCache` and `calendarToIsoFromMonthCodeCache`. Each capped at 1024 entries; resets on overflow so long-running processes don't grow unbounded.
- Static, bounded (`ZonedDateTime::normalizeTimezoneId`): two caches (by `rejectDatetimeStrings` flag), each capped at 1024 entries because the input domain (ISO datetime strings with bracket annotations) is unbounded.
- Static, naturally bounded: `ZonedDateTime::{resolveCanonicalTimezoneId, canonicalizeTimezoneForComparison}` and the `DateTimeZone` cache in `resolveOffsetSecondsAt` are bounded by the IANA set (~400 entries); `CalendarMath::fromJulianDay` bounded by the distinct JDNs referenced; `PureHebrewCalendar::$monthLengthCache` bounded by Hebrew years × ≤13 months.

## Test plan

- [x] Full suite passes (7504 tests, 1466 incomplete — same as master baseline; no regressions).
- [ ] CI must pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)