### PR TITLE
Drop valueOf() from spec-layer types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Most application code should use the porcelain layer. The spec layer is a fully 
 
 ### Deliberate deviations from TC39
 
-The porcelain layer adapts TC39 semantics to PHP-native conventions rather than mirroring the JavaScript API shape 1:1. The spec layer (`Temporal\Spec\`) remains TC39-faithful for anyone needing that.
+The porcelain layer adapts TC39 semantics to PHP-native conventions rather than mirroring the JavaScript API shape 1:1. The spec layer (`Temporal\Spec\`) remains TC39-faithful for anyone needing that, with one small exception (see `valueOf()` below).
 
 Notable differences:
 
@@ -37,6 +37,7 @@ Notable differences:
 - **`fromFields()` takes named arguments, not a property bag.** Each parameter has its own type (`int<1, 12>` for `month`, `Calendar` for `calendar`, etc.) so PHPStan/Psalm can validate call sites fully. Only five classes expose `fromFields()` — the ones whose constructors cannot express every field combination (`PlainDate`, `PlainDateTime`, `PlainYearMonth`, `PlainMonthDay`, `ZonedDateTime`). For `PlainTime`, `Instant`, and `Duration`, the constructor already covers every field.
 - **Option strings replaced by backed enums.** `Overflow::Reject` instead of `'reject'`, `Calendar::Gregory` instead of `'gregory'`, etc.
 - **Time zones and calendars are first-class.** `ZonedDateTime::fromFields()` takes `timeZone` as a required positional parameter; all calendar fields accept the `Calendar` enum rather than an identifier string.
+- **No `valueOf()` on spec-layer types.** The TC39 spec defines `valueOf()` to throw `TypeError` so that `<`, `>`, `+`, etc. fail loudly rather than silently coercing. PHP has no equivalent hook — relational operators on objects walk declared properties, arithmetic operators raise `TypeError` from the engine itself, and there is no language path that calls `valueOf()`. A throw-only method that the runtime never invokes is just dead surface, so the spec layer does not expose it. Use `compare()` (or, for `Instant` / `ZonedDateTime`, the underlying `epochNanoseconds`) when you need ordering. Test262 fixtures that target `valueOf()` are emitted as incomplete by the transpiler.
 
 ## Usage
 

--- a/src/Spec/Duration.php
+++ b/src/Spec/Duration.php
@@ -750,18 +750,6 @@ final class Duration implements Stringable
     }
 
     /**
-     * Throws TypeError to prevent numeric coercion.
-     *
-     * @throws \TypeError always.
-     * @return never
-     * @psalm-api
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError('Use Temporal.Duration.compare() to compare Duration values.');
-    }
-
-    /**
      * Returns the total of this duration as a number in the given unit.
      *
      * Returns an int when the result is a whole number, float otherwise.

--- a/src/Spec/Instant.php
+++ b/src/Spec/Instant.php
@@ -346,22 +346,6 @@ final class Instant implements Stringable
     }
 
     /**
-     * Throws TypeError unconditionally to prevent numeric comparison.
-     *
-     * Mirrors JS Temporal.Instant.prototype.valueOf() which always throws TypeError.
-     *
-     * @psalm-api used by test262 scripts
-     * @throws \TypeError always
-     * @return never
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError(
-            'Use Temporal\\Instant::compare() or epochNanoseconds to compare Temporal\\Instant values.',
-        );
-    }
-
-    /**
      * Returns an ISO 8601 string in UTC, with optional rounding and precision options.
      *
      * Options (all optional):

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -799,18 +799,6 @@ final class PlainDate implements Stringable
         return new self($this->isoYear, $this->isoMonth, $this->isoDay, $calId);
     }
 
-    /**
-     * Always throws TypeError — PlainDate must not be used in arithmetic context.
-     *
-     * @throws \TypeError always.
-     * @psalm-return never
-     * @psalm-api
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError('PlainDate objects are not orderable');
-    }
-
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------

--- a/src/Spec/PlainDateTime.php
+++ b/src/Spec/PlainDateTime.php
@@ -1250,18 +1250,6 @@ final class PlainDateTime implements Stringable
         );
     }
 
-    /**
-     * Always throws TypeError — PlainDateTime must not be used in arithmetic context.
-     *
-     * @throws \TypeError always.
-     * @psalm-return never
-     * @psalm-api
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError('PlainDateTime objects are not orderable');
-    }
-
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -537,18 +537,6 @@ final class PlainMonthDay implements Stringable
     }
 
     /**
-     * Always throws TypeError — PlainMonthDay must not be used in arithmetic context.
-     *
-     * @throws \TypeError always.
-     * @psalm-return never
-     * @psalm-api
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError('PlainMonthDay objects are not orderable');
-    }
-
-    /**
      * Converts this PlainMonthDay to a PlainDate by supplying the year.
      *
      * The day is constrained to the valid range for that year's month (default overflow behaviour).

--- a/src/Spec/PlainTime.php
+++ b/src/Spec/PlainTime.php
@@ -582,18 +582,6 @@ final class PlainTime implements Stringable
         return "{$base}.{$fraction}";
     }
 
-    /**
-     * Always throws TypeError — PlainTime must not be used in arithmetic context.
-     *
-     * @throws \TypeError always.
-     * @psalm-return never
-     * @psalm-api
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError('Use Temporal.PlainTime.compare() to compare Temporal.PlainTime values.');
-    }
-
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------

--- a/src/Spec/PlainYearMonth.php
+++ b/src/Spec/PlainYearMonth.php
@@ -610,18 +610,6 @@ final class PlainYearMonth implements Stringable
     }
 
     /**
-     * Always throws TypeError — PlainYearMonth must not be used in arithmetic context.
-     *
-     * @throws \TypeError always.
-     * @psalm-return never
-     * @psalm-api
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError('PlainYearMonth objects are not orderable');
-    }
-
-    /**
      * Converts this PlainYearMonth to a PlainDate by supplying the day.
      *
      * @param array<array-key, mixed>|object $fields Must contain 'day' key.

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -1873,18 +1873,6 @@ final class ZonedDateTime implements Stringable
         return $out;
     }
 
-    /**
-     * Always throws TypeError — ZonedDateTime must not be used in numeric context.
-     *
-     * @throws \TypeError always.
-     * @psalm-return never
-     * @psalm-api
-     */
-    public function valueOf(): never
-    {
-        throw new \TypeError('Use comparison methods instead of relying on ZonedDateTime object coercion.');
-    }
-
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------

--- a/tests/Test262/scripts/Duration/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/basic.php
@@ -9,4 +9,13 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $d1 = \Temporal\Spec\Duration::from('P3DT1H');
 $d2 = \Temporal\Spec\Duration::from('P3DT1H');
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => d1.valueOf(), "valueOf")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => d1 < d1, "<")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => d1 <= d1, "<=")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => d1 > d1, ">")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => d1 >= d1, ">=")
+Assert::sameValue($d1 === $d1, true, '===');
+Assert::sameValue($d1 === $d2, false, '===');
+Assert::sameValue($d1 !== $d1, false, '!==');
+Assert::sameValue($d1 !== $d2, true, '!==');
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/basic.php
@@ -9,5 +9,4 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $d1 = \Temporal\Spec\Duration::from('P3DT1H');
 $d2 = \Temporal\Spec\Duration::from('P3DT1H');
-Assert::throws(\TypeError::class, function () use (&$d1) { return $d1->valueOf(); }, 'valueOf');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\Duration', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\Duration', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Duration.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\Duration', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Duration.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Duration.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\Duration', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/Duration/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Duration.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\Duration::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/basic.php
@@ -9,5 +9,4 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $instant = new \Temporal\Spec\Instant(100);
 $instant2 = new \Temporal\Spec\Instant(987_654_321);
-Assert::throws(\TypeError::class, function () use (&$instant) { return $instant->valueOf(); }, 'valueOf');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/basic.php
@@ -9,4 +9,13 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $instant = new \Temporal\Spec\Instant(100);
 $instant2 = new \Temporal\Spec\Instant(987_654_321);
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => instant.valueOf(), "valueOf")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => instant < instant, "<")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => instant <= instant, "<=")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => instant > instant, ">")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => instant >= instant, ">=")
+Assert::sameValue($instant === $instant, true, '===');
+Assert::sameValue($instant === $instant2, false, '===');
+Assert::sameValue($instant !== $instant, false, '!==');
+Assert::sameValue($instant !== $instant2, true, '!==');
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\Instant', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\Instant', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Instant.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Instant.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\Instant', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Instant.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/Instant/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof Instant.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\Instant', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\Instant::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/basic.php
@@ -9,4 +9,13 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainDate = \Temporal\Spec\PlainDate::from('1963-02-13');
 $plainDate2 = \Temporal\Spec\PlainDate::from('1963-02-13');
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => plainDate.valueOf(), "valueOf")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => plainDate < plainDate, "<")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => plainDate <= plainDate, "<=")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => plainDate > plainDate, ">")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => plainDate >= plainDate, ">=")
+Assert::sameValue($plainDate === $plainDate, true, '===');
+Assert::sameValue($plainDate === $plainDate2, false, '===');
+Assert::sameValue($plainDate !== $plainDate, false, '!==');
+Assert::sameValue($plainDate !== $plainDate2, true, '!==');
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/basic.php
@@ -9,5 +9,4 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainDate = \Temporal\Spec\PlainDate::from('1963-02-13');
 $plainDate2 = \Temporal\Spec\PlainDate::from('1963-02-13');
-Assert::throws(\TypeError::class, function () use (&$plainDate) { return $plainDate->valueOf(); }, 'valueOf');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainDate', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainDate', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDate.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainDate', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDate.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDate.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainDate', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainDate/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDate.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainDate::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/basic.php
@@ -10,7 +10,4 @@ use Temporal\Tests\Test262\Assert;
 $dt1 = new \Temporal\Spec\PlainDateTime(1963, 2, 13, 9, 36, 29, 123, 456, 789);
 $dt1again = new \Temporal\Spec\PlainDateTime(1963, 2, 13, 9, 36, 29, 123, 456, 789);
 $dt2 = new \Temporal\Spec\PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
-Assert::throws(\TypeError::class, function () use (&$dt1) { return $dt1->valueOf(); }, 'always throws');
-Assert::sameValue($dt1 === $dt1, true, 'object equality implies ===');
-Assert::sameValue($dt1 !== $dt1again, true, 'object non-equality, even if all data is the same, implies !==');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/basic.php
@@ -10,4 +10,15 @@ use Temporal\Tests\Test262\Assert;
 $dt1 = new \Temporal\Spec\PlainDateTime(1963, 2, 13, 9, 36, 29, 123, 456, 789);
 $dt1again = new \Temporal\Spec\PlainDateTime(1963, 2, 13, 9, 36, 29, 123, 456, 789);
 $dt2 = new \Temporal\Spec\PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789);
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => dt1.valueOf(), "always throws")
+Assert::sameValue($dt1 === $dt1, true, 'object equality implies ===');
+Assert::sameValue($dt1 !== $dt1again, true, 'object non-equality, even if all data is the same, implies !==');
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => dt1 < dt1, "< throws (same objects)")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => dt1 < dt2, "< throws (different objects)")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => dt1 > dt1, "> throws (same objects)")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => dt1 > dt2, "> throws (different objects)")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => dt1 <= dt1, "<= does not throw (same objects)")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => dt1 <= dt2, "<= throws (different objects)")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => dt1 >= dt1, ">= throws (same objects)")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => dt1 >= dt2, ">= throws (different objects)")
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainDateTime', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainDateTime', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDateTime.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainDateTime', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDateTime.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDateTime.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainDateTime', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainDateTime/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainDateTime.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/basic.php
@@ -9,5 +9,4 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainMonthDay = \Temporal\Spec\PlainMonthDay::from('1963-02-13');
 $plainMonthDay2 = \Temporal\Spec\PlainMonthDay::from('1963-02-13');
-Assert::throws(\TypeError::class, function () use (&$plainMonthDay) { return $plainMonthDay->valueOf(); }, 'valueOf');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/basic.php
@@ -9,4 +9,13 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainMonthDay = \Temporal\Spec\PlainMonthDay::from('1963-02-13');
 $plainMonthDay2 = \Temporal\Spec\PlainMonthDay::from('1963-02-13');
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => plainMonthDay.valueOf(), "valueOf")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => plainMonthDay < plainMonthDay, "<")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => plainMonthDay <= plainMonthDay, "<=")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => plainMonthDay > plainMonthDay, ">")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => plainMonthDay >= plainMonthDay, ">=")
+Assert::sameValue($plainMonthDay === $plainMonthDay, true, '===');
+Assert::sameValue($plainMonthDay === $plainMonthDay2, false, '===');
+Assert::sameValue($plainMonthDay !== $plainMonthDay, false, '!==');
+Assert::sameValue($plainMonthDay !== $plainMonthDay2, true, '!==');
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainMonthDay', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainMonthDay', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainMonthDay.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainMonthDay.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainMonthDay', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainMonthDay.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainMonthDay/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainMonthDay.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainMonthDay', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainMonthDay::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/basic.php
@@ -9,4 +9,13 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainTime = \Temporal\Spec\PlainTime::from('09:36:29.123456789');
 $plainTime2 = \Temporal\Spec\PlainTime::from('09:36:29.123456789');
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => plainTime.valueOf(), "valueOf")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => plainTime < plainTime, "<")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => plainTime <= plainTime, "<=")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => plainTime > plainTime, ">")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => plainTime >= plainTime, ">=")
+Assert::sameValue($plainTime === $plainTime, true, '===');
+Assert::sameValue($plainTime === $plainTime2, false, '===');
+Assert::sameValue($plainTime !== $plainTime, false, '!==');
+Assert::sameValue($plainTime !== $plainTime2, true, '!==');
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/basic.php
@@ -9,5 +9,4 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainTime = \Temporal\Spec\PlainTime::from('09:36:29.123456789');
 $plainTime2 = \Temporal\Spec\PlainTime::from('09:36:29.123456789');
-Assert::throws(\TypeError::class, function () use (&$plainTime) { return $plainTime->valueOf(); }, 'valueOf');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainTime', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainTime', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainTime.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainTime.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainTime', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainTime.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainTime/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainTime.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainTime', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/basic.php
@@ -9,5 +9,4 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainYearMonth = \Temporal\Spec\PlainYearMonth::from('1963-02');
 $plainYearMonth2 = \Temporal\Spec\PlainYearMonth::from('1963-02');
-Assert::throws(\TypeError::class, function () use (&$plainYearMonth) { return $plainYearMonth->valueOf(); }, 'valueOf');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/basic.php
@@ -9,4 +9,13 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $plainYearMonth = \Temporal\Spec\PlainYearMonth::from('1963-02');
 $plainYearMonth2 = \Temporal\Spec\PlainYearMonth::from('1963-02');
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => plainYearMonth.valueOf(), "valueOf")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => plainYearMonth < plainYearMonth, "<")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => plainYearMonth <= plainYearMonth, "<=")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => plainYearMonth > plainYearMonth, ">")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => plainYearMonth >= plainYearMonth, ">=")
+Assert::sameValue($plainYearMonth === $plainYearMonth, true, '===');
+Assert::sameValue($plainYearMonth === $plainYearMonth2, false, '===');
+Assert::sameValue($plainYearMonth !== $plainYearMonth, false, '!==');
+Assert::sameValue($plainYearMonth !== $plainYearMonth2, true, '!==');
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainYearMonth', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\PlainYearMonth', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainYearMonth.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainYearMonth.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainYearMonth', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainYearMonth.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/PlainYearMonth/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof PlainYearMonth.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\PlainYearMonth', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\PlainYearMonth::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/basic.php
@@ -9,5 +9,4 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $zonedDateTime = new \Temporal\Spec\ZonedDateTime(100, 'UTC');
 $zonedDateTime2 = new \Temporal\Spec\ZonedDateTime(987_654_321, 'UTC');
-Assert::throws(\TypeError::class, function () use (&$zonedDateTime) { return $zonedDateTime->valueOf(); }, 'valueOf');
-Assert::incomplete('PHP comparison operator \'<\' does not trigger valueOf()');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/basic.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/basic.php
@@ -9,4 +9,13 @@ declare(strict_types=1);
 use Temporal\Tests\Test262\Assert;
 $zonedDateTime = new \Temporal\Spec\ZonedDateTime(100, 'UTC');
 $zonedDateTime2 = new \Temporal\Spec\ZonedDateTime(987_654_321, 'UTC');
+// JS-only (PHP spec layer does not expose valueOf(); operators have no hook): assert.throws(TypeError, () => zonedDateTime.valueOf(), "valueOf")
+// JS-only (PHP comparison operator '<' does not trigger valueOf()): assert.throws(TypeError, () => zonedDateTime < zonedDateTime, "<")
+// JS-only (PHP comparison operator '<=' does not trigger valueOf()): assert.throws(TypeError, () => zonedDateTime <= zonedDateTime, "<=")
+// JS-only (PHP comparison operator '>' does not trigger valueOf()): assert.throws(TypeError, () => zonedDateTime > zonedDateTime, ">")
+// JS-only (PHP comparison operator '>=' does not trigger valueOf()): assert.throws(TypeError, () => zonedDateTime >= zonedDateTime, ">=")
+Assert::sameValue($zonedDateTime === $zonedDateTime, true, '===');
+Assert::sameValue($zonedDateTime === $zonedDateTime2, false, '===');
+Assert::sameValue($zonedDateTime !== $zonedDateTime, false, '!==');
+Assert::sameValue($zonedDateTime !== $zonedDateTime2, true, '!==');
 Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\ZonedDateTime', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length-objects.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length-objects.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::methodLength('\Temporal\Spec\ZonedDateTime', 'valueOf', 0);
+Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/length.php
@@ -7,4 +7,4 @@ declare(strict_types=1);
 // Re-generate: composer test262:build
 
 use Temporal\Tests\Test262\Assert;
-Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof ZonedDateTime.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc-objects.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc-objects.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof ZonedDateTime.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\ZonedDateTime', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof ZonedDateTime.prototype.valueOf` is `function`');
-Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');
+Assert::incomplete('PHP spec layer does not expose valueOf(); operators have no hook');

--- a/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc.php
+++ b/tests/Test262/scripts/ZonedDateTime/prototype/valueOf/prop-desc.php
@@ -8,4 +8,4 @@ declare(strict_types=1);
 
 use Temporal\Tests\Test262\Assert;
 Assert::sameValue('function', 'function', '`typeof ZonedDateTime.prototype.valueOf` is `function`');
-Assert::methodExists('\Temporal\Spec\ZonedDateTime', 'valueOf');
+Assert::incomplete('\\Temporal\\Spec\\ZonedDateTime::valueOf() is not yet implemented');

--- a/tools/transpile-test262.mjs
+++ b/tools/transpile-test262.mjs
@@ -319,7 +319,12 @@ class Emitter {
   constructor(source, objectMode = false) {
     this.source = source;
     this.lines = [];
-    this.incomplete = false;   // set when we emit Assert::incomplete
+    this.incomplete = false;   // set when we emit Assert::incomplete (terminates the script)
+    // When a single statement is skipped but the script can keep emitting other
+    // assertions, we record the reason here. At the end of transpileProgram we emit
+    // a trailing Assert::incomplete() so the test surfaces as incomplete overall,
+    // without losing the assertions that come after the skipped statement.
+    this.deferredIncompleteReason = null;
     this.skipOverflow = false; // for the current assertion being built
     // When true, JS object literals become PHP stdClass objects instead of arrays.
     // Used to generate the `<name>-objects.php` companion variants that exercise
@@ -373,6 +378,19 @@ class Emitter {
   }
 
   /**
+   * Drops a single statement (with a `// JS-only (...)` comment for traceability)
+   * and records that the script as a whole should be marked incomplete at the end,
+   * rather than aborting now. Use this when a specific assertion is untranslatable
+   * but later assertions in the same fixture can still be translated faithfully —
+   * e.g. test262 `valueOf/basic.js`, where the valueOf-throws and `<`/`>` checks are
+   * skipped but the `===`/`!==` `assert.sameValue` lines can still run in PHP.
+   */
+  emitSkipAndDefer(node, reason) {
+    this.emitSkipComment(node, reason);
+    this.deferredIncompleteReason ??= reason;
+  }
+
+  /**
    * Emits a `// JS-only (<reason>): <original-js>` comment when a statement is
    * silently dropped (untranslatable JS-only construct that the suite would
    * otherwise discard via Assert::incomplete + PHPUnit's coverage discard for
@@ -403,6 +421,14 @@ class Emitter {
     for (const stmt of otherStmts) {
       this.transpileStatement(stmt);
       if (this.incomplete) break;
+    }
+    // If individual statements were skipped via emitSkipAndDefer (but the script
+    // wasn't aborted via emitIncomplete), surface the reason as a trailing
+    // Assert::incomplete so the test still reports as incomplete overall while
+    // the surrounding translatable assertions kept running.
+    if (!this.incomplete && this.deferredIncompleteReason !== null) {
+      this.lines.push(`Assert::incomplete(${phpStr(this.deferredIncompleteReason)});`);
+      this.incomplete = true;
     }
   }
 
@@ -2104,24 +2130,27 @@ class Emitter {
     }
 
     // PHP comparison operators (<, <=, >, >=) do not call valueOf() and thus cannot
-    // throw TypeError the way JS does. Emit incomplete for these cases.
+    // throw TypeError the way JS does. Skip just this assertion (the rest of the
+    // fixture — e.g. `===` / `!==` sameValue lines — may still translate faithfully)
+    // and defer the incomplete-marker to end of script.
     if (fnNode?.type === 'ArrowFunctionExpression' && fnNode.body?.type === 'BinaryExpression') {
       const op = fnNode.body.operator;
       if (op === '<' || op === '<=' || op === '>' || op === '>=') {
-        this.emitIncomplete(`PHP comparison operator '${op}' does not trigger valueOf()`);
+        this.emitSkipAndDefer(node, `PHP comparison operator '${op}' does not trigger valueOf()`);
         return null;
       }
     }
 
     // Direct `() => obj.valueOf()` invocations: the spec layer no longer exposes
     // valueOf() (PHP has no operator hook that would make it useful), so calling it
-    // would raise BadMethodCallException, not TypeError. Emit incomplete instead.
+    // would raise BadMethodCallException, not TypeError. Skip just this assertion
+    // and defer the incomplete-marker to end of script.
     if (fnNode?.type === 'ArrowFunctionExpression'
         && fnNode.body?.type === 'CallExpression'
         && fnNode.body.callee?.type === 'MemberExpression'
         && !fnNode.body.callee.computed
         && fnNode.body.callee.property?.name === 'valueOf') {
-      this.emitIncomplete('PHP spec layer does not expose valueOf(); operators have no hook');
+      this.emitSkipAndDefer(node, 'PHP spec layer does not expose valueOf(); operators have no hook');
       return null;
     }
 

--- a/tools/transpile-test262.mjs
+++ b/tools/transpile-test262.mjs
@@ -131,16 +131,25 @@ const IMPLEMENTED_HELPERS = new Set([
 ]);
 
 /**
+ * Methods deliberately omitted from the PHP spec layer — fixtures that touch
+ * them are emitted as incomplete with a reason explaining why, rather than
+ * the generic "not yet implemented" wording (which would imply a TODO).
+ */
+const PHP_INTENTIONALLY_ABSENT_METHODS = new Set([
+  'valueOf',
+]);
+
+/** Reason text shown in Assert::incomplete() when a fixture references a deliberately-absent method. */
+const PHP_ABSENT_METHOD_REASONS = {
+  valueOf: 'PHP spec layer does not expose valueOf(); operators have no hook',
+};
+
+/**
  * PHP methods that exist on each Temporal class (static + instance).
  * Used by emitVerifyProperty() to decide whether to emit a real assertion
  * or Assert::incomplete() for a method that is not yet implemented.
  */
 const PHP_IMPLEMENTED_METHODS = {
-  // valueOf() is intentionally NOT listed for any class. PHP has no language hook
-  // equivalent to JS's ToPrimitive, so a throw-only valueOf() cannot prevent the
-  // operators it exists to guard (`<`, `>`, etc.) from giving silent answers. The
-  // spec-layer types simply do not expose the method, and reflection-style fixtures
-  // (Object.getOwnPropertyDescriptor, Function.length) become incomplete.
   Instant:  new Set([
     '__construct', 'from', 'fromEpochMilliseconds', 'fromEpochNanoseconds',
     'compare', 'equals', 'toString', 'toJSON', 'toLocaleString',
@@ -1341,7 +1350,7 @@ class Emitter {
       const method = callee.property.name;
       const key = `${className}::${method}`;
       if (!IMPLEMENTED.has(key)) {
-        this.emitIncomplete(`\\Temporal\\Spec\\${className}::${method}() is not yet implemented`);
+        this.emitIncomplete(incompleteReasonFor(className, method));
         return null;
       }
       const args = this.transpileArgs(node.arguments);
@@ -1500,7 +1509,7 @@ class Emitter {
       const { className, method } = temporal;
       const key = `${className}::${method}`;
       if (!IMPLEMENTED.has(key)) {
-        this.emitIncomplete(`\\Temporal\\Spec\\${className}::${method}() is not yet implemented`);
+        this.emitIncomplete(incompleteReasonFor(className, method));
         return null;
       }
       // JS auto-coerces objects to strings; PHP does not. If an objectVars variable
@@ -1598,7 +1607,7 @@ class Emitter {
         if (isPhpMethodImplemented(cls, propName)) {
           return `Assert::methodExists('${phpClass}', '${propName}')`;
         }
-        this.emitIncomplete(`\\Temporal\\Spec\\${cls}::${propName}() is not yet implemented`);
+        this.emitIncomplete(incompleteReasonFor(cls, propName));
         return null;
       }
 
@@ -1611,7 +1620,7 @@ class Emitter {
         if (isPhpMethodImplemented(cls, propName)) {
           return `Assert::methodExists('${phpClass}', '${propName}')`;
         }
-        this.emitIncomplete(`\\Temporal\\Spec\\${cls}::${propName}() is not yet implemented`);
+        this.emitIncomplete(incompleteReasonFor(cls, propName));
         return null;
       }
 
@@ -1624,7 +1633,7 @@ class Emitter {
             if (isPhpMethodImplemented(cls, method)) {
               return `Assert::methodLength('${phpClass}', '${method}', ${value})`;
             }
-            this.emitIncomplete(`\\Temporal\\Spec\\${cls}::${method}() is not yet implemented`);
+            this.emitIncomplete(incompleteReasonFor(cls, method));
             return null;
           }
           return 'Assert::assertTrue(true)';
@@ -1641,7 +1650,7 @@ class Emitter {
             if (isPhpMethodImplemented(cls, method)) {
               return `Assert::methodLength('${phpClass}', '${method}', ${value})`;
             }
-            this.emitIncomplete(`\\Temporal\\Spec\\${cls}::${method}() is not yet implemented`);
+            this.emitIncomplete(incompleteReasonFor(cls, method));
             return null;
           }
           return 'Assert::assertTrue(true)';
@@ -2512,6 +2521,19 @@ function parseVerifyPropertyTarget(node) {
  */
 function isPhpMethodImplemented(className, method) {
   return PHP_IMPLEMENTED_METHODS[className]?.has(method) ?? false;
+}
+
+/**
+ * Returns the reason text for an Assert::incomplete() when a fixture references
+ * a method that is not exposed by the PHP spec layer. Methods listed in
+ * PHP_INTENTIONALLY_ABSENT_METHODS get a specific "deliberately absent" reason;
+ * everything else gets the generic "not yet implemented" wording.
+ */
+function incompleteReasonFor(className, method) {
+  if (PHP_INTENTIONALLY_ABSENT_METHODS.has(method)) {
+    return PHP_ABSENT_METHOD_REASONS[method] ?? `\\Temporal\\Spec\\${className}::${method}() is intentionally not exposed`;
+  }
+  return `\\Temporal\\Spec\\${className}::${method}() is not yet implemented`;
 }
 
 /** PHP single-quoted string literal. */

--- a/tools/transpile-test262.mjs
+++ b/tools/transpile-test262.mjs
@@ -136,32 +136,37 @@ const IMPLEMENTED_HELPERS = new Set([
  * or Assert::incomplete() for a method that is not yet implemented.
  */
 const PHP_IMPLEMENTED_METHODS = {
+  // valueOf() is intentionally NOT listed for any class. PHP has no language hook
+  // equivalent to JS's ToPrimitive, so a throw-only valueOf() cannot prevent the
+  // operators it exists to guard (`<`, `>`, etc.) from giving silent answers. The
+  // spec-layer types simply do not expose the method, and reflection-style fixtures
+  // (Object.getOwnPropertyDescriptor, Function.length) become incomplete.
   Instant:  new Set([
     '__construct', 'from', 'fromEpochMilliseconds', 'fromEpochNanoseconds',
-    'compare', 'equals', 'valueOf', 'toString', 'toJSON', 'toLocaleString',
+    'compare', 'equals', 'toString', 'toJSON', 'toLocaleString',
     'add', 'subtract', 'round', 'since', 'until', 'toZonedDateTimeISO',
   ]),
   Duration: new Set([
     '__construct', 'from', 'negated', 'abs', 'equals', 'with',
-    'add', 'subtract', 'total', 'toString', 'toJSON', 'toLocaleString', 'valueOf',
+    'add', 'subtract', 'total', 'toString', 'toJSON', 'toLocaleString',
     'compare', 'round',
   ]),
   PlainDate: new Set([
     '__construct', 'from', 'compare',
     'with', 'withCalendar', 'add', 'subtract', 'since', 'until',
     'toPlainDateTime', 'toZonedDateTime', 'toPlainYearMonth', 'toPlainMonthDay',
-    'equals', 'toString', 'toJSON', 'toLocaleString', 'valueOf',
+    'equals', 'toString', 'toJSON', 'toLocaleString',
   ]),
   PlainDateTime: new Set([
     '__construct', 'from', 'compare',
     'with', 'withCalendar', 'withPlainTime', 'add', 'subtract', 'since', 'until', 'round',
-    'equals', 'toString', 'toJSON', 'toLocaleString', 'valueOf',
+    'equals', 'toString', 'toJSON', 'toLocaleString',
     'toPlainDate', 'toPlainTime', 'toZonedDateTime',
   ]),
   PlainTime: new Set([
     '__construct', 'from', 'compare',
     'with', 'add', 'subtract', 'since', 'until',
-    'round', 'equals', 'toString', 'toJSON', 'toLocaleString', 'valueOf',
+    'round', 'equals', 'toString', 'toJSON', 'toLocaleString',
   ]),
   Now: new Set([
     'instant', 'timeZoneId', 'plainDateISO', 'plainTimeISO', 'plainDateTimeISO', 'zonedDateTimeISO',
@@ -169,16 +174,16 @@ const PHP_IMPLEMENTED_METHODS = {
   PlainYearMonth: new Set([
     '__construct', 'from', 'compare',
     'with', 'add', 'subtract', 'since', 'until',
-    'equals', 'toString', 'toJSON', 'toLocaleString', 'valueOf', 'toPlainDate',
+    'equals', 'toString', 'toJSON', 'toLocaleString', 'toPlainDate',
   ]),
   PlainMonthDay: new Set([
     '__construct', 'from',
-    'with', 'equals', 'toString', 'toJSON', 'toLocaleString', 'valueOf', 'toPlainDate',
+    'with', 'equals', 'toString', 'toJSON', 'toLocaleString', 'toPlainDate',
   ]),
   ZonedDateTime: new Set([
     '__construct', 'from', 'compare',
     'add', 'subtract', 'since', 'until', 'round', 'with',
-    'equals', 'toString', 'toJSON', 'toLocaleString', 'valueOf',
+    'equals', 'toString', 'toJSON', 'toLocaleString',
     'toInstant', 'toPlainDate', 'toPlainTime', 'toPlainDateTime',
     'withTimeZone', 'withCalendar', 'withPlainTime',
     'startOfDay', 'getTimeZoneTransition',
@@ -2097,6 +2102,18 @@ class Emitter {
         this.emitIncomplete(`PHP comparison operator '${op}' does not trigger valueOf()`);
         return null;
       }
+    }
+
+    // Direct `() => obj.valueOf()` invocations: the spec layer no longer exposes
+    // valueOf() (PHP has no operator hook that would make it useful), so calling it
+    // would raise BadMethodCallException, not TypeError. Emit incomplete instead.
+    if (fnNode?.type === 'ArrowFunctionExpression'
+        && fnNode.body?.type === 'CallExpression'
+        && fnNode.body.callee?.type === 'MemberExpression'
+        && !fnNode.body.callee.computed
+        && fnNode.body.callee.property?.name === 'valueOf') {
+      this.emitIncomplete('PHP spec layer does not expose valueOf(); operators have no hook');
+      return null;
     }
 
     const fnPhp  = fnNode ? this.transpileExpr(fnNode) : 'fn() => null';


### PR DESCRIPTION
## Summary

- **Removed `valueOf()` from all 8 spec-layer types.** PHP has no language hook equivalent to JS's `ToPrimitive`, so a throw-only `valueOf()` cannot prevent the operators it exists to guard (`<`, `>`, `+`, etc.) — relational operators on objects walk declared properties, arithmetic operators raise `TypeError` from the engine itself, and nothing in the runtime ever calls `valueOf()`. Documented the deviation in `README.md` under "Deliberate deviations from TC39".
- **Adapted `tools/transpile-test262.mjs`** so reflection-style and direct-call valueOf fixtures emit a `// JS-only (...)` comment plus a trailing `Assert::incomplete()`. The 50 regenerated fixtures now carry an accurate "PHP spec layer does not expose valueOf(); operators have no hook" reason instead of the generic "is not yet implemented" wording, and translatable assertions in the same file (`===` / `!==` `sameValue` lines) keep running.

## Details

`8fdfca27 Drop valueOf() from spec-layer types`
- Spec-layer methods: 62.28 % → 64.01 % (denominator −8).
- Per-type method coverage rose 1–3 pts: PlainTime 68 → 70.83 %, PlainDateTime 75.68 → 77.78 %, PlainDate 63.89 → 65.71 %, PlainYearMonth 60 → 62.07 %, PlainMonthDay 55.56 → 58.82 %, Instant 55.56 → 57.69 %, Duration 58.73 → 59.68 %, ZonedDateTime 57.81 → 58.73 %.
- Spec-layer line coverage: 92.10 % → 92.18 %.
- Test262 incomplete count: 2,054 → 2,086.

`5fc37921 test262: distinguish intentionally-absent methods from unimplemented ones`
- Added `PHP_INTENTIONALLY_ABSENT_METHODS` + `incompleteReasonFor()` helper. Reflection fixtures (`length`, `prop-desc`) now carry the accurate reason instead of "is not yet implemented".
- 32 fixtures regenerated. No coverage / count delta.

`318a5f58 test262: defer incomplete-marker so skipped statements don't lose later assertions`
- Added `emitSkipAndDefer()` so a single skipped statement no longer terminates the script. The trailing `Assert::incomplete()` is emitted in the `transpileProgram` epilogue.
- Recovered 4 `===` / `!==` `sameValue` assertions per spec-type basic fixture (PlainDateTime had 2; the rest had 4).
- Assertions: 892,689 → 892,719 (+30 legitimate assertions across 8 fixtures). Tests / incomplete unchanged.

## Test plan

- [x] `composer test262:build` regenerates fixtures cleanly
- [x] Full suite green: `vendor/bin/phpunit --testsuite=porcelain,test262` — 12,221 / 0 fail / 0 errors / 2,086 incomplete / 892,719 assertions
- [x] `composer phpstan` — no errors
- [x] `composer psalm` — no errors
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)