### PR TITLE
Drop dead branches and cover uncovered throws

### DIFF
--- a/src/Spec/Internal/Calendar/CalendarFactory.php
+++ b/src/Spec/Internal/Calendar/CalendarFactory.php
@@ -159,7 +159,10 @@ final class CalendarFactory
             return 'iso8601';
         }
         // Date-like strings: starts with digits and has a dash within the first 7 chars.
-        if (preg_match(pattern: '/^\d/', subject: $cal) === 1 && preg_match(pattern: '/^\d{1,6}-/', subject: $cal) === 1) {
+        if (
+            preg_match(pattern: '/^\d/', subject: $cal) === 1
+            && preg_match(pattern: '/^\d{1,6}-/', subject: $cal) === 1
+        ) {
             return 'iso8601';
         }
         // Plain calendar ID: ASCII-only lowercase (rejects non-ASCII via downstream canonicalize).

--- a/src/Spec/Internal/Calendar/CalendarFactory.php
+++ b/src/Spec/Internal/Calendar/CalendarFactory.php
@@ -91,10 +91,7 @@ final class CalendarFactory
     /**
      * Resolves a property-bag `calendar` field to a canonical calendar ID.
      *
-     * Runs the full pipeline used by every Plain* `from()` property-bag path:
-     * type-check, minus-zero extended-year reject, ISO-string-with-bracket
-     * validation, [u-ca=...] / date-like extraction, and final canonicalization.
-     *
+     * Type-checks $value, then forwards to {@see extractCalendarFromString}.
      * The $context label is used in the TypeError message (e.g. "PlainDate"
      * produces "PlainDate calendar must be a string; got int.").
      *
@@ -106,13 +103,94 @@ final class CalendarFactory
         if (!is_string($value)) {
             throw new \TypeError(sprintf('%s calendar must be a string; got %s.', $context, get_debug_type($value)));
         }
-        // Reject minus-zero extended year in calendar strings.
-        if (preg_match(pattern: '/^-0{6}/', subject: $value) === 1) {
-            throw new InvalidArgumentException(
-                "Cannot use negative zero as extended year in calendar string \"{$value}\".",
-            );
+        return self::extractCalendarFromString($value);
+    }
+
+    /**
+     * Resolves a calendar-field string to a canonical calendar ID.
+     *
+     * Accepts:
+     *   - Bare calendar IDs ("hebrew", "iso8601", ...) — case-insensitive
+     *   - ISO date / datetime / year-month / month-day / time strings, with
+     *     or without a `[u-ca=...]` annotation. No annotation → "iso8601".
+     *
+     * Rejects (InvalidArgumentException):
+     *   - Empty string
+     *   - Minus-zero extended-year strings ("-000000-...")
+     *   - Bracket annotations not preceded by an ISO date prefix
+     *     ("foo[u-ca=hebrew]", "[u-ca=hebrew]", "abc[u-ca=hebrew]")
+     *   - Unknown calendar identifiers
+     *
+     * @throws InvalidArgumentException for invalid/unsupported calendars.
+     */
+    public static function extractCalendarFromString(string $s): string
+    {
+        if ($s === '') {
+            throw new InvalidArgumentException('Calendar ID must not be empty.');
         }
-        return self::canonicalize(self::extractIdFromCalendarString($value));
+        // Reject minus-zero extended year ("-000000" with no further digits).
+        if (preg_match(pattern: '/^-0{6}(?:[^0-9]|$)/', subject: $s) === 1) {
+            throw new InvalidArgumentException("Invalid calendar \"{$s}\": minus-zero year.");
+        }
+        // Per ParseTemporalCalendarString, a string with a bracket annotation
+        // must parse as a Temporal date/time string — i.e. the prefix before
+        // '[' must be a valid ISO date or time prefix. Bare bracket annotations
+        // and bracket annotations following non-Temporal prefixes are RangeError.
+        if (str_contains($s, '[')) {
+            $prefix = substr($s, offset: 0, length: (int) strpos($s, needle: '['));
+            if (!self::looksLikeIsoDateOrTime($prefix)) {
+                throw new InvalidArgumentException(
+                    "Invalid calendar string \"{$s}\": bracket annotation must follow an ISO date or time prefix.",
+                );
+            }
+            $m = null;
+            if (preg_match(pattern: '/\[!?u-ca=([^\]]+)\]/', subject: $s, matches: $m) === 1) {
+                return self::canonicalize($m[1]);
+            }
+            // Bracket without u-ca (e.g. timezone annotation) → default iso8601.
+            return 'iso8601';
+        }
+        // ISO date / datetime / time strings (no annotation) → iso8601.
+        if (self::looksLikeIsoDateOrTime($s)) {
+            return 'iso8601';
+        }
+        // Plain calendar ID.
+        return self::canonicalize($s);
+    }
+
+    /**
+     * Returns true if $s starts with anything that looks like an ISO date or
+     * time prefix: date (YYYY-MM, MM-DD, ±YYYYYY-), datetime (digit-T-digit),
+     * or time form (T-prefix, HH:MM, bare HH, compact HHMM/HHMMSS).
+     */
+    private static function looksLikeIsoDateOrTime(string $s): bool
+    {
+        if ($s === '') {
+            return false;
+        }
+        // Date / datetime.
+        if (
+            preg_match(pattern: '/^\d{2}-\d{2}|^\d{4}-\d{2}|^[+-]\d{6}-/', subject: $s) === 1
+            || preg_match(pattern: '/\d[Tt]\d/', subject: $s) === 1
+        ) {
+            return true;
+        }
+        // Time-only forms.
+        if (preg_match(pattern: '/^[Tt]\d/', subject: $s) === 1) {
+            return true;
+        }
+        if (preg_match(pattern: '/^\d{2}:/', subject: $s) === 1) {
+            return true;
+        }
+        // Bare hour: exactly 2 digits.
+        if (preg_match(pattern: '/^\d{2}$/', subject: $s) === 1) {
+            return true;
+        }
+        // Compact time HHMM/HHMMSS: 4–6 digits NOT followed by '-DD-'.
+        return (
+            preg_match(pattern: '/^\d{4,6}(?:[.,]|\+|$)/', subject: $s) === 1
+            || preg_match(pattern: '/^\d{4,6}-(?!\d{2}-)/', subject: $s) === 1
+        );
     }
 
     /**
@@ -127,53 +205,6 @@ final class CalendarFactory
         }
 
         return in_array($lower, self::KNOWN_CALENDARS, strict: true);
-    }
-
-    /**
-     * Extracts a calendar ID from a calendar-field string.
-     *
-     * Accepts bare calendar IDs ("iso8601", "hebrew", ...), ISO date / datetime
-     * strings ("2020-01-01", "01-01"), and ISO strings carrying a `[u-ca=X]`
-     * annotation. ISO strings carrying a non-`u-ca` bracket annotation
-     * (e.g. `"2020-01-01[UTC]"`) yield "iso8601".
-     *
-     * Per ParseTemporalCalendarString, a string with a bracket annotation must
-     * parse as a Temporal date/time/etc string — i.e. the prefix before the
-     * first '[' must look like an ISO date. Bare bracket annotations and
-     * bracket annotations following non-temporal prefixes are RangeError.
-     */
-    private static function extractIdFromCalendarString(string $cal): string
-    {
-        if (str_contains($cal, '[')) {
-            $prefix = substr($cal, offset: 0, length: (int) strpos($cal, needle: '['));
-            if (preg_match(pattern: '/^\d{1,6}-/', subject: $prefix) !== 1) {
-                throw new InvalidArgumentException(
-                    "Invalid calendar string \"{$cal}\": bracket annotation must follow an ISO date prefix.",
-                );
-            }
-            $m = null;
-            if (preg_match(pattern: '/\[!?u-ca=([^\]]+)\]/', subject: $cal, matches: $m) === 1) {
-                return strtolower($m[1]);
-            }
-            // Bracket without u-ca (e.g. time-zone annotation) → default iso8601.
-            return 'iso8601';
-        }
-        // Date-like strings: starts with digits and has a dash within the first 7 chars.
-        if (
-            preg_match(pattern: '/^\d/', subject: $cal) === 1
-            && preg_match(pattern: '/^\d{1,6}-/', subject: $cal) === 1
-        ) {
-            return 'iso8601';
-        }
-        // Plain calendar ID: ASCII-only lowercase (rejects non-ASCII via downstream canonicalize).
-        $lower = '';
-        $len = strlen($cal);
-        for ($i = 0; $i < $len; $i++) {
-            $c = $cal[$i];
-            $o = ord($c);
-            $lower .= $o >= 0x41 && $o <= 0x5A ? chr($o + 32) : $c;
-        }
-        return $lower;
     }
 
     private static function create(string $id): CalendarProtocol

--- a/src/Spec/Internal/Calendar/CalendarFactory.php
+++ b/src/Spec/Internal/Calendar/CalendarFactory.php
@@ -89,6 +89,33 @@ final class CalendarFactory
     }
 
     /**
+     * Resolves a property-bag `calendar` field to a canonical calendar ID.
+     *
+     * Runs the full pipeline used by every Plain* `from()` property-bag path:
+     * type-check, minus-zero extended-year reject, ISO-string-with-bracket
+     * validation, [u-ca=...] / date-like extraction, and final canonicalization.
+     *
+     * The $context label is used in the TypeError message (e.g. "PlainDate"
+     * produces "PlainDate calendar must be a string; got int.").
+     *
+     * @throws \TypeError                if $value is not a string.
+     * @throws InvalidArgumentException if $value is malformed or names an unknown calendar.
+     */
+    public static function resolveBagCalendar(mixed $value, string $context): string
+    {
+        if (!is_string($value)) {
+            throw new \TypeError(sprintf('%s calendar must be a string; got %s.', $context, get_debug_type($value)));
+        }
+        // Reject minus-zero extended year in calendar strings.
+        if (preg_match(pattern: '/^-0{6}/', subject: $value) === 1) {
+            throw new InvalidArgumentException(
+                "Cannot use negative zero as extended year in calendar string \"{$value}\".",
+            );
+        }
+        return self::canonicalize(self::extractIdFromCalendarString($value));
+    }
+
+    /**
      * Returns true if the given ID (after lowercasing and alias resolution) is a known calendar.
      */
     public static function isKnownCalendar(string $id): bool
@@ -100,6 +127,50 @@ final class CalendarFactory
         }
 
         return in_array($lower, self::KNOWN_CALENDARS, strict: true);
+    }
+
+    /**
+     * Extracts a calendar ID from a calendar-field string.
+     *
+     * Accepts bare calendar IDs ("iso8601", "hebrew", ...), ISO date / datetime
+     * strings ("2020-01-01", "01-01"), and ISO strings carrying a `[u-ca=X]`
+     * annotation. ISO strings carrying a non-`u-ca` bracket annotation
+     * (e.g. `"2020-01-01[UTC]"`) yield "iso8601".
+     *
+     * Per ParseTemporalCalendarString, a string with a bracket annotation must
+     * parse as a Temporal date/time/etc string — i.e. the prefix before the
+     * first '[' must look like an ISO date. Bare bracket annotations and
+     * bracket annotations following non-temporal prefixes are RangeError.
+     */
+    private static function extractIdFromCalendarString(string $cal): string
+    {
+        if (str_contains($cal, '[')) {
+            $prefix = substr($cal, offset: 0, length: (int) strpos($cal, needle: '['));
+            if (preg_match(pattern: '/^\d{1,6}-/', subject: $prefix) !== 1) {
+                throw new InvalidArgumentException(
+                    "Invalid calendar string \"{$cal}\": bracket annotation must follow an ISO date prefix.",
+                );
+            }
+            $m = null;
+            if (preg_match(pattern: '/\[!?u-ca=([^\]]+)\]/', subject: $cal, matches: $m) === 1) {
+                return strtolower($m[1]);
+            }
+            // Bracket without u-ca (e.g. time-zone annotation) → default iso8601.
+            return 'iso8601';
+        }
+        // Date-like strings: starts with digits and has a dash within the first 7 chars.
+        if (preg_match(pattern: '/^\d/', subject: $cal) === 1 && preg_match(pattern: '/^\d{1,6}-/', subject: $cal) === 1) {
+            return 'iso8601';
+        }
+        // Plain calendar ID: ASCII-only lowercase (rejects non-ASCII via downstream canonicalize).
+        $lower = '';
+        $len = strlen($cal);
+        for ($i = 0; $i < $len; $i++) {
+            $c = $cal[$i];
+            $o = ord($c);
+            $lower .= $o >= 0x41 && $o <= 0x5A ? chr($o + 32) : $c;
+        }
+        return $lower;
     }
 
     private static function create(string $id): CalendarProtocol

--- a/src/Spec/Internal/CalendarMath.php
+++ b/src/Spec/Internal/CalendarMath.php
@@ -90,7 +90,7 @@ final class CalendarMath
      *
      * @throws \TypeError if the era value cannot be coerced to a string.
      */
-    public static function resolveEraYear(
+    public static function resolveYearFromEra(
         CalendarProtocol $calendar,
         mixed $eraRaw,
         mixed $eraYearRaw,

--- a/src/Spec/Internal/CalendarMath.php
+++ b/src/Spec/Internal/CalendarMath.php
@@ -104,11 +104,7 @@ final class CalendarMath
         } elseif (is_scalar($eraRaw) || $eraRaw instanceof \Stringable) {
             $eraStr = (string) $eraRaw;
         } else {
-            throw new \TypeError(sprintf(
-                '%s era must be a string; got %s.',
-                $errorContext,
-                get_debug_type($eraRaw),
-            ));
+            throw new \TypeError(sprintf('%s era must be a string; got %s.', $errorContext, get_debug_type($eraRaw)));
         }
         $eraYearInt = self::toFiniteInt($eraYearRaw, "{$errorContext} eraYear");
         return $calendar->resolveEra($eraStr, $eraYearInt);

--- a/src/Spec/Internal/CalendarMath.php
+++ b/src/Spec/Internal/CalendarMath.php
@@ -6,6 +6,7 @@ namespace Temporal\Spec\Internal;
 
 use InvalidArgumentException;
 use Temporal\Spec\Internal\Calendar\CalendarFactory;
+use Temporal\Spec\Internal\Calendar\CalendarProtocol;
 
 /** @internal */
 final class CalendarMath
@@ -76,6 +77,41 @@ final class CalendarMath
             throw new \TypeError("{$className} property bag must have both era and eraYear, or neither.");
         }
         return $hasEra && $hasEraYear;
+    }
+
+    /**
+     * Coerces an `era` bag value to a string per the spec's `to-string`
+     * conversion in PrepareCalendarFields, then delegates to
+     * `$calendar->resolveEra()`. Treats null era or eraYear as absent
+     * (PrepareCalendarFields skips conversion for undefined values).
+     * Returns null for eraless calendars (chinese, dangi); the caller
+     * must handle that case if it implies a later TypeError per
+     * NonISOResolveFields.
+     *
+     * @throws \TypeError if the era value cannot be coerced to a string.
+     */
+    public static function resolveEraYear(
+        CalendarProtocol $calendar,
+        mixed $eraRaw,
+        mixed $eraYearRaw,
+        string $errorContext,
+    ): ?int {
+        if ($eraRaw === null || $eraYearRaw === null) {
+            return null;
+        }
+        if (is_string($eraRaw)) {
+            $eraStr = $eraRaw;
+        } elseif (is_scalar($eraRaw) || $eraRaw instanceof \Stringable) {
+            $eraStr = (string) $eraRaw;
+        } else {
+            throw new \TypeError(sprintf(
+                '%s era must be a string; got %s.',
+                $errorContext,
+                get_debug_type($eraRaw),
+            ));
+        }
+        $eraYearInt = self::toFiniteInt($eraYearRaw, "{$errorContext} eraYear");
+        return $calendar->resolveEra($eraStr, $eraYearInt);
     }
 
     /**

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -470,7 +470,7 @@ final class PlainDate implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainDate::with() year');
         } elseif ($hasEra) {
-            $resolved = CalendarMath::resolveEraYear(
+            $resolved = CalendarMath::resolveYearFromEra(
                 $calendar,
                 $fields['era'],
                 $fields['eraYear'],
@@ -981,7 +981,7 @@ final class PlainDate implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainDate');
+            $resolved = CalendarMath::resolveYearFromEra($calendar, $bag['era'], $bag['eraYear'], 'PlainDate');
             if ($resolved !== null) {
                 $year = $resolved;
             }

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -470,7 +470,12 @@ final class PlainDate implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainDate::with() year');
         } elseif ($hasEra) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'PlainDate::with()');
+            $resolved = CalendarMath::resolveEraYear(
+                $calendar,
+                $fields['era'],
+                $fields['eraYear'],
+                'PlainDate::with()',
+            );
             if ($resolved !== null) {
                 $year = $resolved;
             }

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -943,22 +943,9 @@ final class PlainDate implements Stringable
      */
     private static function fromPropertyBag(array $bag, string $overflow = 'constrain'): self
     {
-        // Validate calendar key if present.
-        $calendarId = null;
-        if (array_key_exists('calendar', $bag)) {
-            /** @var mixed $cal */
-            $cal = $bag['calendar'];
-            if (!is_string($cal)) {
-                throw new \TypeError(sprintf('PlainDate calendar must be a string; got %s.', get_debug_type($cal)));
-            }
-            // Reject minus-zero extended year in date-like calendar strings.
-            if (preg_match('/^-0{6}/', $cal) === 1) {
-                throw new InvalidArgumentException(
-                    "Cannot use negative zero as extended year in calendar string \"{$cal}\".",
-                );
-            }
-            $calendarId = CalendarFactory::canonicalize(self::extractCalendarId($cal));
-        }
+        $calendarId = array_key_exists('calendar', $bag)
+            ? CalendarFactory::resolveBagCalendar($bag['calendar'], 'PlainDate')
+            : null;
 
         $hasEraAndEraYear = CalendarMath::hasEraAndEraYear($bag, $calendarId, 'PlainDate');
         $calendarSupportsEras = CalendarMath::supportsEras($calendarId);
@@ -1761,56 +1748,6 @@ final class PlainDate implements Stringable
         }
 
         return new self($newYear, $newMonth, $newDay, $this->calendarId);
-    }
-
-    /**
-     * Extracts the calendar ID from a calendar string.
-     *
-     * The calendar field in a property bag may be either a plain ID (e.g. 'iso8601')
-     * or an ISO 8601 date/datetime string carrying a [u-ca=...] annotation. In the
-     * latter case the annotation's value is the calendar ID; when absent, 'iso8601'
-     * is the default.
-     *
-     * Only ASCII-lowercase comparison is used for case-folding. Calendar IDs that
-     * contain non-ASCII characters that would be lowercased differently by Unicode
-     * case-folding (e.g. U+0130 İ) are not lowercased and will not match 'iso8601'.
-     */
-    private static function extractCalendarId(string $cal): string
-    {
-        // A string that looks like an ISO date/datetime (e.g. "2020-01-01", "01-01",
-        // "2020-01", "2016-12-31T23:59:60") is an ISO date string used as a
-        // calendar field. Extract the [u-ca=...] annotation if present; otherwise
-        // the implicit calendar is iso8601.
-        //
-        // Valid date-string forms (per TC39 spec, must START with digits and have
-        // date structure):
-        //   YYYY-MM  YYYY-MM-DD  YYYY-MM-DDTHH...  MM-DD
-        // These all START with digits and contain a '-' within the first 7 chars.
-        if (str_contains($cal, '[')) {
-            $m = null;
-            if (preg_match('/\[!?u-ca=([^\]]+)\]/', $cal, $m) === 1) {
-                return strtolower($m[1]);
-            }
-            // Bracket without u-ca → default iso8601.
-            return 'iso8601';
-        }
-        // Detect date-like strings: must start with ASCII digits and have a dash
-        // within the first 7 chars (to distinguish "2020-01-01" from "iso8601").
-        if (preg_match('/^\d/', $cal) === 1 && preg_match('/^\d{1,6}-/', $cal) === 1) {
-            // ISO date string with no bracket → implicit iso8601.
-            return 'iso8601';
-        }
-        // A plain calendar ID: lowercase for case-insensitive comparison.
-        // Use ASCII-only lowercase to reject non-ASCII characters like U+0130 (İ).
-        $lower = '';
-        $len = strlen($cal);
-        for ($i = 0; $i < $len; $i++) {
-            $c = $cal[$i];
-            $o = ord($c);
-            // Only lowercase ASCII A-Z; leave all other bytes unchanged.
-            $lower .= $o >= 0x41 && $o <= 0x5A ? chr($o + 32) : $c;
-        }
-        return $lower;
     }
 
     #[\Override]

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -793,7 +793,7 @@ final class PlainDate implements Stringable
      */
     public function withCalendar(string $calendar): self
     {
-        $calId = ZonedDateTime::extractCalendarFromString($calendar);
+        $calId = CalendarFactory::extractCalendarFromString($calendar);
         return new self($this->isoYear, $this->isoMonth, $this->isoDay, $calId);
     }
 

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -470,16 +470,9 @@ final class PlainDate implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainDate::with() year');
         } elseif ($hasEra) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $fields['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $fields['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'PlainDate::with()');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 
@@ -996,16 +989,9 @@ final class PlainDate implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $bag['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $bag['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'PlainDate eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainDate');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -1572,6 +1572,8 @@ final class PlainDate implements Stringable
     /**
      * Returns [years, months, remainingDays] between two dates.
      *
+     * Caller must pass dates in (earlier, later) order: (y1,m1,d1) ≤ (y2,m2,d2).
+     *
      * $receiverIsY2: true when the caller's receiver corresponds to y2 (the later
      * argument), false when it corresponds to y1 (the earlier argument).  The anchor
      * for the day-remainder calculation is always derived from the RECEIVER's date so
@@ -1590,18 +1592,6 @@ final class PlainDate implements Stringable
         int $d2,
         bool $receiverIsY2 = true,
     ): array {
-        $sign = $y2 > $y1 || $y2 === $y1 && ($m2 > $m1 || $m2 === $m1 && $d2 >= $d1) ? 1 : -1;
-
-        // Track whether the receiver ends up as y1 or y2 after a potential swap.
-        // A swap happens when sign < 0, which flips the receiver position.
-        $receiverIsY2AfterSwap = $receiverIsY2;
-
-        // Work in the positive direction; negate result if sign is negative.
-        if ($sign < 0) {
-            [$y1, $m1, $d1, $y2, $m2, $d2] = [$y2, $m2, $d2, $y1, $m1, $d1];
-            $receiverIsY2AfterSwap = !$receiverIsY2;
-        }
-
         $years = $y2 - $y1;
         $months = $m2 - $m1;
 
@@ -1622,10 +1612,7 @@ final class PlainDate implements Stringable
             }
         }
 
-        // Compute anchor and remaining days from the RECEIVER's perspective.
-        // receiverIsY2AfterSwap=true  → receiver=y2 → anchor = y2 − months (backward from receiver)
-        // receiverIsY2AfterSwap=false → receiver=y1 → anchor = y1 + months (forward from receiver)
-        if ($receiverIsY2AfterSwap) {
+        if ($receiverIsY2) {
             // Anchor from y2 (receiver) going backward.
             $anchorMonth = $m2 - $months;
             $anchorYear = $y2 - $years;
@@ -1653,7 +1640,7 @@ final class PlainDate implements Stringable
                 - CalendarMath::toJulianDay($anchorYear, $anchorMonth, $anchorDay);
         }
 
-        return [$sign * $years, $sign * $months, $sign * $days];
+        return [$years, $months, $days];
     }
 
     /**

--- a/src/Spec/PlainDateTime.php
+++ b/src/Spec/PlainDateTime.php
@@ -599,16 +599,9 @@ final class PlainDateTime implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainDateTime::with() year');
         } elseif ($hasEra) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $fields['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $fields['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'PlainDateTime::with()');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 
@@ -1466,16 +1459,9 @@ final class PlainDateTime implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $bag['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $bag['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'PlainDateTime eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainDateTime');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 

--- a/src/Spec/PlainDateTime.php
+++ b/src/Spec/PlainDateTime.php
@@ -599,7 +599,12 @@ final class PlainDateTime implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainDateTime::with() year');
         } elseif ($hasEra) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'PlainDateTime::with()');
+            $resolved = CalendarMath::resolveEraYear(
+                $calendar,
+                $fields['era'],
+                $fields['eraYear'],
+                'PlainDateTime::with()',
+            );
             if ($resolved !== null) {
                 $year = $resolved;
             }

--- a/src/Spec/PlainDateTime.php
+++ b/src/Spec/PlainDateTime.php
@@ -599,7 +599,7 @@ final class PlainDateTime implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainDateTime::with() year');
         } elseif ($hasEra) {
-            $resolved = CalendarMath::resolveEraYear(
+            $resolved = CalendarMath::resolveYearFromEra(
                 $calendar,
                 $fields['era'],
                 $fields['eraYear'],
@@ -1464,7 +1464,7 @@ final class PlainDateTime implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainDateTime');
+            $resolved = CalendarMath::resolveYearFromEra($calendar, $bag['era'], $bag['eraYear'], 'PlainDateTime');
             if ($resolved !== null) {
                 $year = $resolved;
             }

--- a/src/Spec/PlainDateTime.php
+++ b/src/Spec/PlainDateTime.php
@@ -1233,7 +1233,7 @@ final class PlainDateTime implements Stringable
      */
     public function withCalendar(string $calendar): self
     {
-        $calId = ZonedDateTime::extractCalendarFromString($calendar);
+        $calId = CalendarFactory::extractCalendarFromString($calendar);
         return new self(
             $this->isoYear,
             $this->isoMonth,
@@ -1424,16 +1424,10 @@ final class PlainDateTime implements Stringable
      */
     private static function fromPropertyBag(array $bag, string $overflow = 'constrain'): self
     {
-        // Validate calendar key if present (delegates to ZonedDateTime::extractCalendarFromString
-        // which rejects minus-zero years, unknown calendars, and empty strings).
+        // Validate calendar key if present.
         $calendarId = null;
         if (array_key_exists('calendar', $bag)) {
-            /** @var mixed $cal */
-            $cal = $bag['calendar'];
-            if (!is_string($cal)) {
-                throw new \TypeError(sprintf('PlainDateTime calendar must be a string; got %s.', get_debug_type($cal)));
-            }
-            $calendarId = ZonedDateTime::extractCalendarFromString($cal);
+            $calendarId = CalendarFactory::resolveBagCalendar($bag['calendar'], 'PlainDateTime');
         }
 
         $hasEraAndEraYear = CalendarMath::hasEraAndEraYear($bag, $calendarId, 'PlainDateTime');

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -679,15 +679,6 @@ final class PlainMonthDay implements Stringable
                         "PlainMonthDay::from() cannot parse \"{$s}\": Z (UTC) designator is not valid.",
                     );
                 }
-            } else {
-                // No time — check for Z or offset immediately following the date portion.
-                $dateLen = str_starts_with($s, '--') ? 7 : 5;
-                $rest = substr(string: $s, offset: $dateLen);
-                if ($rest !== '' && preg_match('/^[Zz]|^[+-]\d{2}/', $rest) === 1) {
-                    throw new InvalidArgumentException(
-                        "PlainMonthDay::from() cannot parse \"{$s}\": UTC offset without time is not valid.",
-                    );
-                }
             }
 
             $calendarId = CalendarMath::validateAnnotations($m[7], $s);
@@ -749,18 +740,6 @@ final class PlainMonthDay implements Stringable
         } else {
             $month = (int) substr(string: $dateRest, offset: 1, length: 2);
             $day = (int) substr(string: $dateRest, offset: 4, length: 2);
-        }
-
-        // Check for UTC offset without time — NOT valid for PlainMonthDay.
-        if ($m[3] === '') {
-            // No time component. Check if there's a Z or offset after the date portion.
-            $dateLen = strlen($yearRaw) + strlen($dateRest);
-            $rest = substr(string: $s, offset: $dateLen);
-            if ($rest !== '' && preg_match('/^[Zz]|^[+-]\d{2}/', $rest) === 1) {
-                throw new InvalidArgumentException(
-                    "PlainMonthDay::from() cannot parse \"{$s}\": UTC offset without time is not valid.",
-                );
-            }
         }
 
         // Validate the time portion if present.

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -828,25 +828,9 @@ final class PlainMonthDay implements Stringable
      */
     private static function fromPropertyBag(array $bag, string $overflow): self
     {
-        // Validate calendar if present.
-        $calendarId = null;
-        if (array_key_exists('calendar', $bag)) {
-            /** @var mixed $calRaw */
-            $calRaw = $bag['calendar'];
-            if (!is_string($calRaw)) {
-                throw new \TypeError(sprintf(
-                    'PlainMonthDay::from() calendar must be a string; got %s.',
-                    get_debug_type($calRaw),
-                ));
-            }
-            // Reject minus-zero extended year in calendar strings.
-            if (preg_match('/^-0{6}/', $calRaw) === 1) {
-                throw new InvalidArgumentException(
-                    "Cannot use negative zero as extended year in calendar string \"{$calRaw}\".",
-                );
-            }
-            $calendarId = CalendarFactory::canonicalize(self::extractCalendarId($calRaw));
-        }
+        $calendarId = array_key_exists('calendar', $bag)
+            ? CalendarFactory::resolveBagCalendar($bag['calendar'], 'PlainMonthDay')
+            : null;
 
         $hasMonth = array_key_exists('month', $bag) && $bag['month'] !== null;
         $hasMonthCode = array_key_exists('monthCode', $bag) && $bag['monthCode'] !== null;
@@ -1209,38 +1193,6 @@ final class PlainMonthDay implements Stringable
         $calYear = $calendar->year(1972, 7, 1);
         [$isoY, $isoM, $isoD] = $calendar->calendarToIsoFromMonthCode($calYear, $monthCode, $day, 'constrain');
         return new self($isoM, $isoD, $calendarId, $isoY);
-    }
-
-    /**
-     * Extracts and validates the calendar ID from a calendar string.
-     *
-     * Accepts bare calendar IDs ("iso8601"), ISO date strings ("2020-01-01", "01-01"),
-     * and strings with [u-ca=X] annotations. Returns the lowercase calendar ID.
-     * Throws for unsupported calendars.
-     */
-    private static function extractCalendarId(string $cal): string
-    {
-        if (str_contains($cal, '[')) {
-            $m = null;
-            if (preg_match('/\[!?u-ca=([^\]]+)\]/', $cal, $m) === 1) {
-                return strtolower($m[1]);
-            }
-            // Bracket without u-ca → default iso8601.
-            return 'iso8601';
-        }
-        // Detect date-like strings: starts with digits and has a dash within the first 7 chars.
-        if (preg_match('/^\d/', $cal) === 1 && preg_match('/^\d{1,6}-/', $cal) === 1) {
-            return 'iso8601';
-        }
-        // Plain calendar ID: ASCII-only lowercase.
-        $lower = '';
-        $len = strlen($cal);
-        for ($i = 0; $i < $len; $i++) {
-            $c = $cal[$i];
-            $o = ord($c);
-            $lower .= $o >= 0x41 && $o <= 0x5A ? chr($o + 32) : $c;
-        }
-        return $lower;
     }
 
     #[\Override]

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -567,16 +567,9 @@ final class PlainMonthDay implements Stringable
 
         // Resolve era + eraYear for non-ISO calendars.
         if ($calendar !== null && $hasEra && $hasEraYear) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $bag['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $bag['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'toPlainDate() eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'toPlainDate()');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 
@@ -915,21 +908,14 @@ final class PlainMonthDay implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && $hasEraAndEraYear) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $bag['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $bag['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'PlainMonthDay::from() eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    if ($year !== null && $year !== $resolved) {
-                        throw new InvalidArgumentException(
-                            "Conflicting year ({$year}) and era+eraYear (resolved to {$resolved}).",
-                        );
-                    }
-                    $year = $resolved;
+            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainMonthDay::from()');
+            if ($resolved !== null) {
+                if ($year !== null && $year !== $resolved) {
+                    throw new InvalidArgumentException(
+                        "Conflicting year ({$year}) and era+eraYear (resolved to {$resolved}).",
+                    );
                 }
+                $year = $resolved;
             }
         }
 

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -992,18 +992,7 @@ final class PlainMonthDay implements Stringable
             }
         }
 
-        // For the stored referenceISOYear: use 1972 if the day is valid for 1972,
-        // otherwise use the provided year (for cases like Feb 29 constrained to 28 in common year).
-        $refYear = 1972;
-        /**
-         * @psalm-suppress UnnecessaryVarAnnotation — Mago loses narrowing across if/else branches
-         */
-        $maxDayIn1972 = CalendarMath::calcDaysInMonth(1972, $month);
-        if ($day > $maxDayIn1972) {
-            $refYear = $year;
-        }
-
-        return new self($month, $day, $calendarId, $refYear);
+        return new self($month, $day, $calendarId, 1972);
     }
 
     /**

--- a/src/Spec/PlainMonthDay.php
+++ b/src/Spec/PlainMonthDay.php
@@ -567,7 +567,7 @@ final class PlainMonthDay implements Stringable
 
         // Resolve era + eraYear for non-ISO calendars.
         if ($calendar !== null && $hasEra && $hasEraYear) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'toPlainDate()');
+            $resolved = CalendarMath::resolveYearFromEra($calendar, $bag['era'], $bag['eraYear'], 'toPlainDate()');
             if ($resolved !== null) {
                 $year = $resolved;
             }
@@ -871,7 +871,12 @@ final class PlainMonthDay implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && $hasEraAndEraYear) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainMonthDay::from()');
+            $resolved = CalendarMath::resolveYearFromEra(
+                $calendar,
+                $bag['era'],
+                $bag['eraYear'],
+                'PlainMonthDay::from()',
+            );
             if ($resolved !== null) {
                 if ($year !== null && $year !== $resolved) {
                     throw new InvalidArgumentException(

--- a/src/Spec/PlainYearMonth.php
+++ b/src/Spec/PlainYearMonth.php
@@ -428,16 +428,9 @@ final class PlainYearMonth implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainYearMonth::with() year');
         } elseif ($hasEra) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $fields['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $fields['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'PlainYearMonth::with()');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 
@@ -841,16 +834,9 @@ final class PlainYearMonth implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $bag['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $bag['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'PlainYearMonth eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainYearMonth');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 

--- a/src/Spec/PlainYearMonth.php
+++ b/src/Spec/PlainYearMonth.php
@@ -428,7 +428,7 @@ final class PlainYearMonth implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainYearMonth::with() year');
         } elseif ($hasEra) {
-            $resolved = CalendarMath::resolveEraYear(
+            $resolved = CalendarMath::resolveYearFromEra(
                 $calendar,
                 $fields['era'],
                 $fields['eraYear'],
@@ -824,7 +824,7 @@ final class PlainYearMonth implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'PlainYearMonth');
+            $resolved = CalendarMath::resolveYearFromEra($calendar, $bag['era'], $bag['eraYear'], 'PlainYearMonth');
             if ($resolved !== null) {
                 $year = $resolved;
             }

--- a/src/Spec/PlainYearMonth.php
+++ b/src/Spec/PlainYearMonth.php
@@ -790,24 +790,9 @@ final class PlainYearMonth implements Stringable
      */
     private static function fromPropertyBag(array $bag, string $overflow = 'constrain'): self
     {
-        // Validate calendar key if present.
-        $calendarId = null;
-        if (array_key_exists('calendar', $bag)) {
-            /** @var mixed $cal */
-            $cal = $bag['calendar'];
-            if (!is_string($cal)) {
-                throw new \TypeError(sprintf(
-                    'PlainYearMonth calendar must be a string; got %s.',
-                    get_debug_type($cal),
-                ));
-            }
-            if (preg_match('/^-0{6}/', $cal) === 1) {
-                throw new InvalidArgumentException(
-                    "Cannot use negative zero as extended year in calendar string \"{$cal}\".",
-                );
-            }
-            $calendarId = CalendarFactory::canonicalize(self::extractCalendarId($cal));
-        }
+        $calendarId = array_key_exists('calendar', $bag)
+            ? CalendarFactory::resolveBagCalendar($bag['calendar'], 'PlainYearMonth')
+            : null;
 
         $hasEraAndEraYear = CalendarMath::hasEraAndEraYear($bag, $calendarId, 'PlainYearMonth');
         $calendarSupportsEras = CalendarMath::supportsEras($calendarId);
@@ -1498,32 +1483,6 @@ final class PlainYearMonth implements Stringable
             return sprintf('+%06d', $year);
         }
         return sprintf('%04d', $year);
-    }
-
-    /**
-     * Extracts the calendar ID from a calendar string (same logic as PlainDate).
-     */
-    private static function extractCalendarId(string $cal): string
-    {
-        if (str_contains($cal, '[')) {
-            $m = null;
-            if (preg_match('/\[!?u-ca=([^\]]+)\]/', $cal, $m) === 1) {
-                return strtolower($m[1]);
-            }
-            return 'iso8601';
-        }
-        if (preg_match('/^\d/', $cal) === 1 && preg_match('/^\d{1,6}-/', $cal) === 1) {
-            return 'iso8601';
-        }
-        // ASCII-only lowercase.
-        $lower = '';
-        $len = strlen($cal);
-        for ($i = 0; $i < $len; $i++) {
-            $c = $cal[$i];
-            $o = ord($c);
-            $lower .= $o >= 0x41 && $o <= 0x5A ? chr($o + 32) : $c;
-        }
-        return $lower;
     }
 
     /**

--- a/src/Spec/PlainYearMonth.php
+++ b/src/Spec/PlainYearMonth.php
@@ -428,7 +428,12 @@ final class PlainYearMonth implements Stringable
         if ($hasYear) {
             $year = CalendarMath::toFiniteInt($fields['year'], 'PlainYearMonth::with() year');
         } elseif ($hasEra) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'PlainYearMonth::with()');
+            $resolved = CalendarMath::resolveEraYear(
+                $calendar,
+                $fields['era'],
+                $fields['eraYear'],
+                'PlainYearMonth::with()',
+            );
             if ($resolved !== null) {
                 $year = $resolved;
             }

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -1524,16 +1524,9 @@ final class ZonedDateTime implements Stringable
             if ($hasYear) {
                 $year = CalendarMath::toFiniteInt($fields['year'], 'ZonedDateTime::with() year');
             } elseif ($hasEra) {
-                /** @var mixed $eraRaw */
-                $eraRaw = $fields['era'];
-                /** @var mixed $eraYearRaw */
-                $eraYearRaw = $fields['eraYear'];
-                if (is_string($eraRaw) && $eraYearRaw !== null) {
-                    $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'eraYear');
-                    $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                    if ($resolved !== null) {
-                        $year = $resolved;
-                    }
+                $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'ZonedDateTime::with()');
+                if ($resolved !== null) {
+                    $year = $resolved;
                 }
             }
 
@@ -2738,16 +2731,9 @@ final class ZonedDateTime implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            /** @var mixed $eraRaw */
-            $eraRaw = $bag['era'];
-            /** @var mixed $eraYearRaw */
-            $eraYearRaw = $bag['eraYear'];
-            if (is_string($eraRaw) && $eraYearRaw !== null) {
-                $eraYearInt = CalendarMath::toFiniteInt($eraYearRaw, 'eraYear');
-                $resolved = $calendar->resolveEra($eraRaw, $eraYearInt);
-                if ($resolved !== null) {
-                    $year = $resolved;
-                }
+            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'ZonedDateTime');
+            if ($resolved !== null) {
+                $year = $resolved;
             }
         }
 

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -655,7 +655,7 @@ final class ZonedDateTime implements Stringable
      */
     public function withCalendar(string $calendar): self
     {
-        $calId = self::extractCalendarFromString($calendar);
+        $calId = CalendarFactory::extractCalendarFromString($calendar);
         [$epochSec, $subNs] = $this->getEpochParts();
         return self::fromEpochParts($epochSec, $subNs, $this->timeZoneId, $calId);
     }
@@ -1875,65 +1875,6 @@ final class ZonedDateTime implements Stringable
     // -------------------------------------------------------------------------
 
     /**
-     * Extracts and validates a calendar ID from a string.
-     *
-     * Accepts:
-     *   - 'iso8601' (case-insensitive)
-     *   - ISO date/datetime/year-month/month-day strings (no annotation → iso8601,
-     *     [u-ca=iso8601] → iso8601, other [u-ca=X] → throw)
-     *
-     * Rejects:
-     *   - Empty string
-     *   - Minus-zero extended year strings
-     *   - Unknown calendar IDs
-     *
-     * @throws InvalidArgumentException for invalid/unsupported calendars.
-     * @internal Used by PlainDate/PlainDateTime for calendar validation.
-     * @psalm-suppress UnusedReturnValue — callers invoke this only for validation (side-effects/throws)
-     * @psalm-api
-     */
-    public static function extractCalendarFromString(string $s): string
-    {
-        if ($s === '') {
-            throw new InvalidArgumentException('Calendar ID must not be empty.');
-        }
-        // Reject minus-zero extended year.
-        if (preg_match('/^-0{6}(?:[^0-9]|$)/', $s) === 1) {
-            throw new InvalidArgumentException("Invalid calendar \"{$s}\": minus-zero year.");
-        }
-        // Check for [u-ca=X] annotation.
-        $m = null;
-        if (preg_match('/\[u-ca=([^\]]+)\]/', $s, $m) === 1) {
-            return CalendarFactory::canonicalize($m[1]);
-        }
-        // ISO date/datetime strings → iso8601 (check BEFORE time-only, to avoid ambiguity).
-        // Match: date patterns (YYYY-MM, MM-DD, ±YYYYYY-) or datetime T-separator after digits.
-        if (preg_match('/^\d{2}-\d{2}|^\d{4}-\d{2}|^[+-]\d{6}-/', $s) === 1 || preg_match('/\d[Tt]\d/', $s) === 1) {
-            return 'iso8601';
-        }
-        // Time-only strings (no calendar annotation) → iso8601.
-        // These are checked AFTER date strings to avoid false positives on year-like digits.
-        if (preg_match('/^[Tt]\d/', $s) === 1) {
-            return 'iso8601';
-        }
-        // Extended time: starts with 2 digits followed by colon (HH:MM or HH:MM:SS).
-        if (preg_match('/^\d{2}:/', $s) === 1) {
-            return 'iso8601';
-        }
-        // Bare hour: exactly 2 digits (HH alone, no suffix).
-        if (preg_match('/^\d{2}$/', $s) === 1) {
-            return 'iso8601';
-        }
-        // Compact time HHMMSS or HHMM: 4–6 digits NOT followed by '-'
-        // (4 or 6 digits followed by end-of-string, fraction, or +/- offset).
-        if (preg_match('/^\d{4,6}(?:[.,]|\+|$)/', $s) === 1 || preg_match('/^\d{4,6}-(?!\d{2}-)/', $s) === 1) {
-            return 'iso8601';
-        }
-        // Plain calendar ID: validate through CalendarFactory.
-        return CalendarFactory::canonicalize($s);
-    }
-
-    /**
      * @internal Used by PlainDate/PlainDateTime for timezone validation.
      * @psalm-api
      */
@@ -2634,12 +2575,7 @@ final class ZonedDateTime implements Stringable
         // Validate calendar first (spec validates calendar before required fields).
         $calendarId = 'iso8601';
         if (array_key_exists('calendar', $bag)) {
-            /** @var mixed $calRaw */
-            $calRaw = $bag['calendar'];
-            if (!is_string($calRaw)) {
-                throw new \TypeError('ZonedDateTime calendar must be a string.');
-            }
-            $calendarId = self::extractCalendarFromString($calRaw);
+            $calendarId = CalendarFactory::resolveBagCalendar($bag['calendar'], 'ZonedDateTime');
         }
 
         // Must have a timeZone key.

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -1524,7 +1524,7 @@ final class ZonedDateTime implements Stringable
             if ($hasYear) {
                 $year = CalendarMath::toFiniteInt($fields['year'], 'ZonedDateTime::with() year');
             } elseif ($hasEra) {
-                $resolved = CalendarMath::resolveEraYear(
+                $resolved = CalendarMath::resolveYearFromEra(
                     $calendar,
                     $fields['era'],
                     $fields['eraYear'],
@@ -2736,7 +2736,7 @@ final class ZonedDateTime implements Stringable
 
         // Resolve era + eraYear if present (overrides year for era-based calendars).
         if ($calendar !== null && array_key_exists('era', $bag) && array_key_exists('eraYear', $bag)) {
-            $resolved = CalendarMath::resolveEraYear($calendar, $bag['era'], $bag['eraYear'], 'ZonedDateTime');
+            $resolved = CalendarMath::resolveYearFromEra($calendar, $bag['era'], $bag['eraYear'], 'ZonedDateTime');
             if ($resolved !== null) {
                 $year = $resolved;
             }

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -1524,7 +1524,12 @@ final class ZonedDateTime implements Stringable
             if ($hasYear) {
                 $year = CalendarMath::toFiniteInt($fields['year'], 'ZonedDateTime::with() year');
             } elseif ($hasEra) {
-                $resolved = CalendarMath::resolveEraYear($calendar, $fields['era'], $fields['eraYear'], 'ZonedDateTime::with()');
+                $resolved = CalendarMath::resolveEraYear(
+                    $calendar,
+                    $fields['era'],
+                    $fields['eraYear'],
+                    'ZonedDateTime::with()',
+                );
                 if ($resolved !== null) {
                     $year = $resolved;
                 }

--- a/tests/Porcelain/NonIsoCalendarAcceptanceTest.php
+++ b/tests/Porcelain/NonIsoCalendarAcceptanceTest.php
@@ -408,14 +408,16 @@ final class NonIsoCalendarAcceptanceTest extends TestCase
 
     public function testExtractCalendarFromStringAcceptsKnownCalendar(): void
     {
-        $result = ZonedDateTime::extractCalendarFromString('hebrew');
+        $result = \Temporal\Spec\Internal\Calendar\CalendarFactory::extractCalendarFromString('hebrew');
 
         static::assertSame('hebrew', $result);
     }
 
     public function testExtractCalendarFromStringAcceptsAnnotation(): void
     {
-        $result = ZonedDateTime::extractCalendarFromString('2024-01-15[u-ca=japanese]');
+        $result = \Temporal\Spec\Internal\Calendar\CalendarFactory::extractCalendarFromString(
+            '2024-01-15[u-ca=japanese]',
+        );
 
         static::assertSame('japanese', $result);
     }
@@ -423,7 +425,7 @@ final class NonIsoCalendarAcceptanceTest extends TestCase
     public function testExtractCalendarFromStringRejectsUnknownCalendar(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        ZonedDateTime::extractCalendarFromString('nonsense');
+        \Temporal\Spec\Internal\Calendar\CalendarFactory::extractCalendarFromString('nonsense');
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Porcelain/PlainDateTest.php
+++ b/tests/Porcelain/PlainDateTest.php
@@ -715,6 +715,36 @@ final class PlainDateTest extends TestCase
         static::assertSame(5, $dur->days);
     }
 
+    public function testSinceThrowsWhenYearsRoundingExceedsIsoRange(): void
+    {
+        $from = new PlainDate(1970, 1, 1);
+        $to = new PlainDate(1971, 1, 1);
+
+        $this->expectException(InvalidArgumentException::class);
+        $from->since(
+            $to,
+            largestUnit: Unit::Year,
+            smallestUnit: Unit::Year,
+            roundingMode: RoundingMode::HalfExpand,
+            roundingIncrement: 1_000_000,
+        );
+    }
+
+    public function testUntilThrowsWhenYearsRoundingExceedsIsoRange(): void
+    {
+        $from = new PlainDate(1970, 1, 1);
+        $to = new PlainDate(1971, 1, 1);
+
+        $this->expectException(InvalidArgumentException::class);
+        $from->until(
+            $to,
+            largestUnit: Unit::Year,
+            smallestUnit: Unit::Year,
+            roundingMode: RoundingMode::HalfExpand,
+            roundingIncrement: 1_000_000,
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Calendar::fromId
     // -------------------------------------------------------------------------

--- a/tests/Porcelain/PlainMonthDayTest.php
+++ b/tests/Porcelain/PlainMonthDayTest.php
@@ -385,9 +385,14 @@ final class PlainMonthDayTest extends TemporalTestCase
         // Spec: PrepareCalendarFields runs ToPositiveIntegerWithTruncation on
         // `month` regardless of calendar, so a non-ISO calendar must reject 0
         // or negative months. Upstream test262 only covers the ISO path.
+        // The 0 literal violates the int<1, 12> PHPDoc on the porcelain
+        // signature; we suppress the analyzer warnings to verify the runtime
+        // safety net still fires.
         $this->expectException(InvalidArgumentException::class);
 
-        PlainMonthDay::fromFields(month: 0, day: 1, calendar: Calendar::Gregory, year: 2024);
+        /** @psalm-suppress InvalidArgument */
+        // @mago-ignore analysis:invalid-argument
+        PlainMonthDay::fromFields(month: 0, day: 1, calendar: Calendar::Gregory, year: 2024); // @phpstan-ignore argument.type
     }
 
     public function testFromFieldsRejectsNonPositiveDayOnNonIsoCalendar(): void
@@ -396,7 +401,9 @@ final class PlainMonthDayTest extends TemporalTestCase
         // negative-month-or-day fixture, which upstream test262 lacks.
         $this->expectException(InvalidArgumentException::class);
 
-        PlainMonthDay::fromFields(month: 1, day: 0, calendar: Calendar::Gregory, year: 2024);
+        /** @psalm-suppress InvalidArgument */
+        // @mago-ignore analysis:invalid-argument
+        PlainMonthDay::fromFields(month: 1, day: 0, calendar: Calendar::Gregory, year: 2024); // @phpstan-ignore argument.type
     }
 
     public function testFromFieldsRejectsNonPositiveDayOnNonIsoCalendarWithMonthCodeNoYear(): void
@@ -406,7 +413,9 @@ final class PlainMonthDayTest extends TemporalTestCase
         // Distinct code path from the year-provided variant above.
         $this->expectException(InvalidArgumentException::class);
 
-        PlainMonthDay::fromFields(monthCode: 'M01', day: 0, calendar: Calendar::Gregory);
+        /** @psalm-suppress InvalidArgument */
+        // @mago-ignore analysis:invalid-argument
+        PlainMonthDay::fromFields(monthCode: 'M01', day: 0, calendar: Calendar::Gregory); // @phpstan-ignore argument.type
     }
 
     public function testFromFieldsRequiresYearOnEralessCalendarEvenWithEraAndEraYear(): void

--- a/tests/Porcelain/PlainMonthDayTest.php
+++ b/tests/Porcelain/PlainMonthDayTest.php
@@ -427,13 +427,7 @@ final class PlainMonthDayTest extends TemporalTestCase
         // calendar has no era support to fall back on.
         $this->expectException(\TypeError::class);
 
-        PlainMonthDay::fromFields(
-            month: 5,
-            day: 1,
-            calendar: Calendar::Chinese,
-            era: 'x',
-            eraYear: 1,
-        );
+        PlainMonthDay::fromFields(month: 5, day: 1, calendar: Calendar::Chinese, era: 'x', eraYear: 1);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Porcelain/PlainMonthDayTest.php
+++ b/tests/Porcelain/PlainMonthDayTest.php
@@ -399,6 +399,34 @@ final class PlainMonthDayTest extends TemporalTestCase
         PlainMonthDay::fromFields(month: 1, day: 0, calendar: Calendar::Gregory, year: 2024);
     }
 
+    public function testFromFieldsRejectsNonPositiveDayOnNonIsoCalendarWithMonthCodeNoYear(): void
+    {
+        // Spec: ToPositiveIntegerWithTruncation rejects day ≤ 0 in
+        // PrepareCalendarFields, regardless of which other fields are present.
+        // Distinct code path from the year-provided variant above.
+        $this->expectException(InvalidArgumentException::class);
+
+        PlainMonthDay::fromFields(monthCode: 'M01', day: 0, calendar: Calendar::Gregory);
+    }
+
+    public function testFromFieldsRequiresYearOnEralessCalendarEvenWithEraAndEraYear(): void
+    {
+        // Spec: CalendarExtraFields returns era/era-year only when
+        // CalendarSupportsEra is true. For 'chinese' and 'dangi', era and
+        // eraYear are silently ignored; with year/monthCode also missing,
+        // NonISOResolveFields throws TypeError because Year is unset and the
+        // calendar has no era support to fall back on.
+        $this->expectException(\TypeError::class);
+
+        PlainMonthDay::fromFields(
+            month: 5,
+            day: 1,
+            calendar: Calendar::Chinese,
+            era: 'x',
+            eraYear: 1,
+        );
+    }
+
     // -------------------------------------------------------------------------
     // with() expanded fields
     // -------------------------------------------------------------------------

--- a/tests/Porcelain/PlainMonthDayTest.php
+++ b/tests/Porcelain/PlainMonthDayTest.php
@@ -380,6 +380,25 @@ final class PlainMonthDayTest extends TemporalTestCase
         PlainMonthDay::fromFields(monthCode: 'M05L', day: 1, calendar: Calendar::Hebrew, year: 5783);
     }
 
+    public function testFromFieldsRejectsNonPositiveMonthOnNonIsoCalendar(): void
+    {
+        // Spec: PrepareCalendarFields runs ToPositiveIntegerWithTruncation on
+        // `month` regardless of calendar, so a non-ISO calendar must reject 0
+        // or negative months. Upstream test262 only covers the ISO path.
+        $this->expectException(InvalidArgumentException::class);
+
+        PlainMonthDay::fromFields(month: 0, day: 1, calendar: Calendar::Gregory, year: 2024);
+    }
+
+    public function testFromFieldsRejectsNonPositiveDayOnNonIsoCalendar(): void
+    {
+        // Spec: same positivity rule for `day`. Non-ISO companion to the ISO
+        // negative-month-or-day fixture, which upstream test262 lacks.
+        $this->expectException(InvalidArgumentException::class);
+
+        PlainMonthDay::fromFields(month: 1, day: 0, calendar: Calendar::Gregory, year: 2024);
+    }
+
     // -------------------------------------------------------------------------
     // with() expanded fields
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Mutation/coverage cleanup pass on the Spec layer: most commits either remove a branch that's structurally unreachable given the actual call shape, or add porcelain tests for a throw that test262 leaves uncovered. Plus one bug fix (`era: 5` was silently dropped — spec says coerce to `"5"` and let canonicalization throw `RangeError`), one validation tightening (malformed bracket-annotated calendar strings), and a refactor pair (rename + calendar-string parser consolidation) that fell out of a spot-refactor review of the branch.

Net for the branch: **+301 / −394 lines**, 10 source/test files touched. PHPStan, Psalm, Mago lint+analyze+format, porcelain (900/900) and test262 (11,332/0/0/2,022 incomplete) all green locally.

Corpus gaps surfaced along the way are filed in #26.

## Per-commit metrics

- `7c52768b Drop dead refYear branch in PlainMonthDay::fromPropertyBag` — 1 file, +1/−12. The ISO `$refYear = $year` fallback was unreachable: 1972 is a leap year so `calcDaysInMonth($year, $month) ≤ calcDaysInMonth(1972, $month)` for every month, and the prior overflow block already clamped/rejected. Hardcoded the 1972 reference per `CalendarMonthDayToISOReferenceDate`. Drops a `@psalm-suppress`.
- `8d8a3ce1 Cover non-ISO PlainMonthDay::fromFields positivity checks` — 1 file (test), +19. test262's `negative-month-or-day.js` only exercises ISO; added two porcelain tests routing through `Calendar::Gregory` for the non-ISO branch's month/day positivity guards.
- `5e16640f Cover non-year non-ISO PlainMonthDay::fromFields edge cases` — 1 file (test), +28. Two more uncovered throws in the no-year non-ISO branch (`day: 0` positivity guard; eraless-calendar era+eraYear without year/monthCode).
- `c5964469 Coerce non-string era field per spec ToString conversion` — 7 files, +82/−107. **Bug fix.** `is_string($eraRaw)` silently dropped non-string eras; spec applies `ToString` then `CanonicalizeEraInCalendar`. e.g. `{calendar: 'gregory', era: 5, eraYear: 1, monthCode: 'M01', day: 1}` was returning a valid PlainMonthDay where spec mandates `RangeError`. Centralized the coerce+resolve logic into `CalendarMath::resolveEraYear` (handles the 10 sites across Plain{Date,DateTime,MonthDay,YearMonth} and ZonedDateTime, both `from()` and `with()`). Net code removed: 25 lines.
- `cc448223 Reject malformed bracket-annotated property-bag calendar strings` — 4 files, +80/−161. Strings like `"foo[bar]"`, `"[u-ca=hebrew]"`, `"abc[u-ca=hebrew]"` were silently accepted instead of throwing `RangeError`. `ParseTemporalCalendarString` requires the prefix before `[` to be a valid Temporal date string — added the prefix validation and consolidated three near-identical `extractCalendarId` helpers + canonicalize boilerplate into `CalendarFactory::resolveBagCalendar()`. Net code removed: 81 lines.
- `9bf29327 Drop dead swap branch in PlainDate::calendarDiff` — 1 file, +4/−17. The function's sole caller pre-sorts to (earlier, later) order, so the internal sign-detection + swap path was never reachable. Removed the swap, `$sign` multiplier, and `$receiverIsY2AfterSwap` shadow; documented the precondition.
- `7260358c Cover smallestUnit=years rounding-out-of-range throw` — 1 file (test), +30. Adds the missing porcelain test for the years-rounding overflow throw.
- `1b3a1c6e Drop dead UTC-offset-without-time throws in PlainMonthDay::fromString` — 1 file, −21. Both regexes already confine `Z` and `[+-]\d\d` to the time block, so a no-time input with a trailing UTC marker fails the regex and falls through to the generic ISO 8601 throw. The dedicated checks could never fire.
- `49475531 Apply mago format to recently-touched files` — 7 files, +30/−17. Pure whitespace fix-up to satisfy `composer mago-check` after the earlier commits landed lines outside the 120-char line-width policy.
- `7ef904c0 Rename CalendarMath::resolveEraYear to resolveYearFromEra` — 6 files, +16/−11. Pure rename. The function takes `era` + `eraYear` and returns the absolute year — every caller does `$year = $resolved` immediately after — so the old name read like it returned an `eraYear`, which it doesn't.
- `5691e30b Consolidate calendar-string parsers; extend bracket-prefix check to all paths` — 5 files, +96/−133. `ZonedDateTime::extractCalendarFromString` and `CalendarFactory::resolveBagCalendar` did the same job from two layers with subtly different rules (the former missed cc448223's bracket-prefix validation; the latter missed time-shaped prefixes). Folded into `CalendarFactory::extractCalendarFromString` with a single `looksLikeIsoDateOrTime` shape classifier reused for both the no-bracket short-circuit and the bracket-prefix check. `resolveBagCalendar` is now a thin type-check + delegate. All five calendar-string entry points (`Plain*::withCalendar`, `ZonedDateTime::withCalendar`, and `PlainDateTime`/`ZonedDateTime::fromPropertyBag`) now go through one parser with one rule set, including the bracket-validation fix. Test262's existing `T11:30[u-ca=…]` corpus exercises the time-prefix path. Net code removed: 37 lines.

## Test plan

- [x] `composer phpstan` — clean (level 9)
- [x] `composer psalm` — clean (level 1)
- [x] `composer mago` (lint + analyze) — clean
- [x] `composer mago-check` (format) — clean
- [x] `vendor/bin/phpunit --testsuite=porcelain` — 900 / 0 fail / 0 errors
- [x] `vendor/bin/phpunit --testsuite=test262` — 11,332 / 0 fail / 0 errors / 2,022 incomplete (unchanged from master)
- [x] `composer infection` — 100% MSI on touched files (25 killed, 1 caught by static analysis)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)