### PR TITLE
Add native DateTimeImmutable interop on porcelain value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Until 1.0.0 the public API may change between minor versions.
 
 ### Added
 
+- **`fromDateTime` / `toDateTime` on porcelain value types.** Native `\DateTimeImmutable` interop for `Temporal\Instant` (both directions, optional `\DateTimeZone` arg, defaults to UTC), `Temporal\ZonedDateTime` (both directions, preserves the zone id), and `fromDateTime` on `Temporal\PlainDateTime`, `Temporal\PlainDate`, `Temporal\PlainTime`. Sub-microsecond Temporal bits are zero on conversion (PHP's `\DateTimeImmutable` is microsecond-precision). Unblocks "wrap your own clock" testing without a library-blessed clock-injection seam — see issue #19 for rationale.
 - **`Temporal\Exception\` hierarchy.** Introduces a `TemporalException` marker interface and concrete classes (`InvalidArgument`, `RangeError`) that extend the corresponding SPL parents (`\InvalidArgumentException`, `\RangeException`). Porcelain throw sites in `Calendar::fromId()` and `RoundingMode::{to,from}PhpRoundingMode()` now throw `Temporal\Exception\InvalidArgument`; existing `catch (\InvalidArgumentException)` / `catch (\LogicException)` clauses keep working because the SPL parents are preserved. The marker interface lets consumers catch every Temporal-origin throwable through a single base. Spec-layer throw sites still emit bare SPL exceptions and will be retrofitted onto this hierarchy in subsequent minors.
 
 ### Changed

--- a/mago.toml
+++ b/mago.toml
@@ -23,7 +23,7 @@ level = "error"
 # 25+ methods plus a full disambiguation/offset-option/calendar matrix).
 [linter.rules.too-many-methods]
 level = "error"
-threshold = 130
+threshold = 140
 
 # PlainDate has 13+ virtual properties; PlainDateTime has 22 (9 time fields + 13 calendar)
 # ZonedDateTime has 29 (3 stored + 1 private cache + 25 virtual properties per TC39 spec)

--- a/src/Instant.php
+++ b/src/Instant.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal;
 
+use Temporal\Spec\Internal\DateTimeFields;
 use Temporal\Trait\HasEpochProperties;
 use Temporal\Trait\HasEpochSpec;
 
@@ -61,6 +62,32 @@ final class Instant implements \Stringable, \JsonSerializable, HasEpochSpec
     public static function fromEpochNanoseconds(int $epochNanoseconds): self
     {
         return self::fromSpec(Spec\Instant::fromEpochNanoseconds($epochNanoseconds));
+    }
+
+    /**
+     * Creates an Instant from a PHP `\DateTimeInterface`.
+     *
+     * PHP's `\DateTimeImmutable` carries microsecond precision; sub-microsecond
+     * Temporal bits (the lowest three decimal digits of `epochNanoseconds`) are
+     * therefore always zero on the resulting Instant.
+     */
+    public static function fromDateTime(\DateTimeInterface $dt): self
+    {
+        return new self(DateTimeFields::epochNanoseconds($dt));
+    }
+
+    /**
+     * Returns a `\DateTimeImmutable` for the same instant, in `$tz` (default UTC).
+     *
+     * The result has microsecond precision; sub-microsecond bits of the Temporal
+     * `epochNanoseconds` are dropped (they cannot be represented by PHP's
+     * native date-time types).
+     *
+     * @param \DateTimeZone|null $tz Display time zone, or null for UTC.
+     */
+    public function toDateTime(?\DateTimeZone $tz = null): \DateTimeImmutable
+    {
+        return DateTimeFields::toDateTime($this->spec->epochNanoseconds, $tz ?? new \DateTimeZone('UTC'));
     }
 
     /**

--- a/src/PlainDate.php
+++ b/src/PlainDate.php
@@ -113,7 +113,7 @@ final class PlainDate implements \Stringable, \JsonSerializable, HasYearMonthSpe
      *
      * The year/month/day are read from `$dt`'s own time zone (via the `Y`, `n`,
      * `j` format specifiers); the time-of-day and time-zone identifier are
-     * dropped because PlainDate is dateless of those.
+     * dropped because PlainDate carries neither.
      *
      * @param \DateTimeInterface $dt       Source date-time; its own zone determines the civil date.
      * @param Calendar           $calendar Calendar projection (default ISO 8601).

--- a/src/PlainDate.php
+++ b/src/PlainDate.php
@@ -109,6 +109,23 @@ final class PlainDate implements \Stringable, \JsonSerializable, HasYearMonthSpe
     }
 
     /**
+     * Creates a PlainDate from a PHP `\DateTimeInterface`.
+     *
+     * The year/month/day are read from `$dt`'s own time zone (via the `Y`, `n`,
+     * `j` format specifiers); the time-of-day and time-zone identifier are
+     * dropped because PlainDate is dateless of those.
+     *
+     * @param \DateTimeInterface $dt       Source date-time; its own zone determines the civil date.
+     * @param Calendar           $calendar Calendar projection (default ISO 8601).
+     */
+    public static function fromDateTime(\DateTimeInterface $dt, Calendar $calendar = Calendar::Iso8601): self
+    {
+        return self::fromSpec(
+            new SpecPlainDate((int) $dt->format('Y'), (int) $dt->format('n'), (int) $dt->format('j'), $calendar->value),
+        );
+    }
+
+    /**
      * Compares two PlainDates chronologically.
      *
      * @return int Negative if $one is earlier, positive if later, zero if equal.

--- a/src/PlainDateTime.php
+++ b/src/PlainDateTime.php
@@ -174,6 +174,40 @@ final class PlainDateTime implements
     }
 
     /**
+     * Creates a PlainDateTime from a PHP `\DateTimeInterface`.
+     *
+     * The civil year/month/day/hour/minute/second/microsecond are read from
+     * `$dt`'s own time zone (via the `Y`, `n`, `j`, `G`, `i`, `s`, `u` format
+     * specifiers); the time-zone identifier itself is dropped because
+     * PlainDateTime is zoneless.
+     *
+     * PHP's `\DateTimeImmutable` carries microsecond precision; the resulting
+     * PlainDateTime always has `nanosecond = 0`.
+     *
+     * @param \DateTimeInterface $dt       Source date-time; its own zone determines the civil fields.
+     * @param Calendar           $calendar Calendar projection (default ISO 8601).
+     */
+    public static function fromDateTime(\DateTimeInterface $dt, Calendar $calendar = Calendar::Iso8601): self
+    {
+        $u = (int) $dt->format('u');
+
+        return self::fromSpec(
+            new SpecPlainDateTime(
+                (int) $dt->format('Y'),
+                (int) $dt->format('n'),
+                (int) $dt->format('j'),
+                (int) $dt->format('G'),
+                (int) $dt->format('i'),
+                (int) $dt->format('s'),
+                intdiv(num1: $u, num2: 1000),
+                $u % 1000,
+                0,
+                $calendar->value,
+            ),
+        );
+    }
+
+    /**
      * Compares two PlainDateTimes chronologically.
      *
      * @return int Negative if $one is earlier, positive if later, zero if equal.

--- a/src/PlainTime.php
+++ b/src/PlainTime.php
@@ -54,6 +54,30 @@ final class PlainTime implements \Stringable, \JsonSerializable, HasTimeOfDaySpe
     }
 
     /**
+     * Creates a PlainTime from a PHP `\DateTimeInterface`.
+     *
+     * The hour/minute/second/microsecond are read from `$dt`'s own time zone
+     * (via the `G`, `i`, `s`, `u` format specifiers); date and zone identifier
+     * are dropped.
+     *
+     * PHP's `\DateTimeImmutable` carries microsecond precision; the resulting
+     * PlainTime always has `nanosecond = 0`.
+     */
+    public static function fromDateTime(\DateTimeInterface $dt): self
+    {
+        $u = (int) $dt->format('u');
+
+        return new self(
+            (int) $dt->format('G'),
+            (int) $dt->format('i'),
+            (int) $dt->format('s'),
+            intdiv(num1: $u, num2: 1000),
+            $u % 1000,
+            0,
+        );
+    }
+
+    /**
      * Compares two PlainTime values.
      *
      * @return int -1, 0, or 1.

--- a/src/Spec/Internal/DateTimeFields.php
+++ b/src/Spec/Internal/DateTimeFields.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Temporal\Spec\Internal;
+
+/**
+ * Internal helpers for converting between epoch-nanosecond integers and PHP's
+ * `\DateTimeInterface`/`\DateTimeImmutable`.
+ *
+ * Used by `Temporal\Instant::{fromDateTime,toDateTime}` and
+ * `Temporal\ZonedDateTime::{fromDateTime,toDateTime}`. The other porcelain
+ * `fromDateTime()` factories (`Temporal\PlainDateTime`, `Temporal\PlainDate`,
+ * `Temporal\PlainTime`) extract individual calendar fields directly from the
+ * source `\DateTimeInterface` and do not go through this helper.
+ *
+ * Although the namespace is `Temporal\Spec\Internal\`, this helper isn't
+ * strictly spec-layer machinery — it's placed here to keep all internal-only
+ * helpers in one namespace. As with everything in `Temporal\Spec\Internal\`,
+ * it is not part of the public BC contract: signatures, behavior, and
+ * existence may change between any two releases.
+ */
+final class DateTimeFields
+{
+    /** Not instantiable.
+     * @psalm-suppress UnusedConstructor
+     */
+    private function __construct() {}
+
+    /**
+     * Returns the epoch nanosecond count of `$dt` with sub-microsecond bits
+     * zeroed.
+     *
+     * PHP's `\DateTimeInterface` carries microsecond precision via the `u`
+     * format specifier, so the lowest three decimal digits of the result are
+     * always zero. This matches the loss-of-precision contract documented on
+     * the porcelain `fromDateTime()` factories.
+     */
+    public static function epochNanoseconds(\DateTimeInterface $dt): int
+    {
+        return (($dt->getTimestamp() * 1_000_000) + (int) $dt->format('u')) * 1_000;
+    }
+
+    /**
+     * Builds a `\DateTimeImmutable` for the given epoch nanoseconds, displayed
+     * in `$tz`.
+     *
+     * PHP's native date-time types only carry microsecond precision, so the
+     * sub-microsecond bits of `$epochNanoseconds` (the lowest three decimal
+     * digits) are dropped. This matches the loss-of-precision contract
+     * documented on the porcelain `toDateTime()` methods.
+     *
+     * Because this helper lives in `Temporal\Spec\Internal\`, it is not part
+     * of the public BC contract and may change between any two releases.
+     */
+    public static function toDateTime(int $epochNanoseconds, \DateTimeZone $tz): \DateTimeImmutable
+    {
+        $us = intdiv(num1: $epochNanoseconds, num2: 1_000);
+        $secs = intdiv(num1: $us, num2: 1_000_000);
+        $usOfSec = $us % 1_000_000;
+        if ($usOfSec < 0) {
+            $usOfSec += 1_000_000;
+            $secs -= 1;
+        }
+
+        $dt = \DateTimeImmutable::createFromFormat(
+            'U.u',
+            sprintf('%d.%06d', $secs, $usOfSec),
+            new \DateTimeZone('UTC'),
+        );
+        \assert($dt !== false, description: 'createFromFormat U.u with integer-formatted input must succeed');
+
+        return $dt->setTimezone($tz);
+    }
+}

--- a/src/Spec/Internal/DateTimeFields.php
+++ b/src/Spec/Internal/DateTimeFields.php
@@ -35,10 +35,31 @@ final class DateTimeFields
      * format specifier, so the lowest three decimal digits of the result are
      * always zero. This matches the loss-of-precision contract documented on
      * the porcelain `fromDateTime()` factories.
+     *
+     * @throws \InvalidArgumentException if `$dt`'s instant lies outside the
+     *         int64 nanosecond range (roughly the years 1678–2262 around
+     *         the Unix epoch).
      */
     public static function epochNanoseconds(\DateTimeInterface $dt): int
     {
-        return (($dt->getTimestamp() * 1_000_000) + (int) $dt->format('u')) * 1_000;
+        $ts = $dt->getTimestamp();
+        // PHP's int64 nanosecond range covers ~±292 years around the Unix
+        // epoch. Beyond that, `$ts × NS_PER_SECOND` overflows to float and
+        // the `int` return type would raise a TypeError before the porcelain
+        // factory could surface a meaningful range error.
+        // The threshold is one less than intdiv(PHP_INT_MAX, NS_PER_SECOND)
+        // = 9_223_372_036 so that the full product plus the maximum
+        // microsecond contribution (999_999 × 1_000 = 999_999_000) stays
+        // within int64: 9_223_372_035 × 10⁹ + 999_999_000 < PHP_INT_MAX.
+        $tsMax = 9_223_372_035;
+        if ($ts > $tsMax || $ts < -$tsMax) {
+            throw new \InvalidArgumentException(sprintf(
+                "DateTime '%s' is outside the representable int64 nanosecond range.",
+                $dt->format(\DateTimeInterface::RFC3339),
+            ));
+        }
+
+        return ($ts * 1_000_000_000) + ((int) $dt->format('u') * 1_000);
     }
 
     /**

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Temporal;
 
+use Temporal\Spec\Internal\DateTimeFields;
 use Temporal\Trait\HasDayOfMonthProperties;
 use Temporal\Trait\HasDayOfMonthSpec;
 use Temporal\Trait\HasEpochProperties;
@@ -220,6 +221,30 @@ final class ZonedDateTime implements
     public static function compare(self $one, self $two): int
     {
         return Spec\ZonedDateTime::compare($one->spec, $two->spec);
+    }
+
+    /**
+     * Creates a ZonedDateTime from a PHP `\DateTimeInterface`.
+     *
+     * The zone of `$dt` (as returned by `\DateTimeZone::getName()`) is used as
+     * the resulting `timeZoneId`; this preserves both IANA names like
+     * `Europe/Vienna` and fixed-offset strings like `+05:30`.
+     *
+     * PHP's `\DateTimeImmutable` carries microsecond precision; sub-microsecond
+     * Temporal bits (the lowest three decimal digits of `epochNanoseconds`) are
+     * therefore always zero on the resulting ZonedDateTime.
+     */
+    public static function fromDateTime(\DateTimeInterface $dt): self
+    {
+        // Mago's stubs type \DateTimeInterface::getTimezone() as \DateTimeZone|false; in practice
+        // it never returns false for \DateTimeImmutable. PHPStan and Psalm correctly model the
+        // runtime. Suppress Mago here rather than adding a runtime check the other analyzers
+        // (correctly) flag as redundant.
+        // @mago-ignore analysis:invalid-method-access
+        // @mago-ignore analysis:mixed-argument
+        $tzId = $dt->getTimezone()->getName();
+
+        return new self(DateTimeFields::epochNanoseconds($dt), $tzId);
     }
 
     // -------------------------------------------------------------------------
@@ -473,6 +498,23 @@ final class ZonedDateTime implements
     public function toInstant(): Instant
     {
         return Instant::fromSpec($this->spec->toInstant());
+    }
+
+    /**
+     * Returns a `\DateTimeImmutable` for the same instant in this ZonedDateTime's
+     * time zone.
+     *
+     * The result has microsecond precision; sub-microsecond bits of the Temporal
+     * `epochNanoseconds` are dropped (they cannot be represented by PHP's
+     * native date-time types). Fixed-offset zones like `+05:30` are passed
+     * through to `\DateTimeZone` as-is.
+     */
+    public function toDateTime(): \DateTimeImmutable
+    {
+        $tzId = $this->spec->timeZoneId;
+        \assert($tzId !== '', description: 'spec layer guarantees a non-empty time zone id');
+
+        return DateTimeFields::toDateTime($this->spec->epochNanoseconds, new \DateTimeZone($tzId));
     }
 
     /**

--- a/tests/Porcelain/InstantTest.php
+++ b/tests/Porcelain/InstantTest.php
@@ -641,4 +641,107 @@ final class InstantTest extends TemporalTestCase
 
         static::assertSame(5, $d->seconds);
     }
+
+    // -------------------------------------------------------------------------
+    // fromDateTime() / toDateTime()
+    // -------------------------------------------------------------------------
+
+    public function testFromDateTimeRoundTripUtc(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T12:30:45.123456', new \DateTimeZone('UTC'));
+        $i = Instant::fromDateTime($dt);
+
+        static::assertSame(1_592_224_245_123_456_000, $i->epochNanoseconds);
+
+        $back = $i->toDateTime();
+        static::assertSame('2020-06-15T12:30:45.123456+00:00', $back->format('Y-m-d\TH:i:s.uP'));
+    }
+
+    public function testFromDateTimeNonUtcInputCollapsesToInstant(): void
+    {
+        // Same instant as 2020-06-15T12:30:45.123456 UTC, but expressed in Asia/Tokyo.
+        $dt = new \DateTimeImmutable('2020-06-15T21:30:45.123456', new \DateTimeZone('Asia/Tokyo'));
+        $i = Instant::fromDateTime($dt);
+
+        static::assertSame(1_592_224_245_123_456_000, $i->epochNanoseconds);
+    }
+
+    public function testToDateTimeDefaultsToUtc(): void
+    {
+        $i = new Instant(1_592_224_245_000_000_000);
+        $dt = $i->toDateTime();
+
+        static::assertSame('UTC', $dt->format('e'));
+        static::assertSame('2020-06-15T12:30:45+00:00', $dt->format('Y-m-d\TH:i:sP'));
+    }
+
+    public function testToDateTimeAcceptsExplicitTimeZone(): void
+    {
+        $i = new Instant(1_592_224_245_000_000_000); // 2020-06-15T12:30:45Z
+        $dt = $i->toDateTime(new \DateTimeZone('Asia/Tokyo'));
+
+        static::assertSame('Asia/Tokyo', $dt->format('e'));
+        static::assertSame('2020-06-15T21:30:45+09:00', $dt->format('Y-m-d\TH:i:sP'));
+    }
+
+    public function testFromDateTimeDropsSubMicrosecondBitsByDocumentedContract(): void
+    {
+        // Build an Instant with sub-microsecond precision, convert through DateTime,
+        // and confirm the lowest three decimal digits are zeroed (not preserved).
+        $i = new Instant(1_592_224_245_123_456_789);
+        $dt = $i->toDateTime();
+        $back = Instant::fromDateTime($dt);
+
+        static::assertSame(1_592_224_245_123_456_000, $back->epochNanoseconds);
+    }
+
+    public function testToDateTimeAtEpochZero(): void
+    {
+        $i = new Instant(0);
+        $dt = $i->toDateTime();
+
+        static::assertSame(0, $dt->getTimestamp());
+        static::assertSame('000000', $dt->format('u'));
+        static::assertSame('1970-01-01T00:00:00+00:00', $dt->format('Y-m-d\TH:i:sP'));
+    }
+
+    public function testToDateTimeNegativeEpochNanosecondsRoundTripsExactly(): void
+    {
+        // -1.5 ms before epoch: tests that floored division puts us in
+        // "1969-12-31 23:59:59.998500 UTC", not "1970-01-01 00:00:00 -.0015".
+        $i = new Instant(-1_500_000);
+        $dt = $i->toDateTime();
+
+        static::assertSame('1969-12-31T23:59:59.998500+00:00', $dt->format('Y-m-d\TH:i:s.uP'));
+
+        $back = Instant::fromDateTime($dt);
+        static::assertSame(-1_500_000, $back->epochNanoseconds);
+    }
+
+    public function testToDateTimeNegativeEpochSecondsBoundary(): void
+    {
+        // Exactly 1 second before epoch — usOfSec is zero, so the floor-borrow
+        // branch must NOT trigger. Catches an off-by-one in the if-condition.
+        $i = new Instant(-1_000_000_000);
+        $dt = $i->toDateTime();
+
+        static::assertSame('1969-12-31T23:59:59.000000+00:00', $dt->format('Y-m-d\TH:i:s.uP'));
+        static::assertSame(-1_000_000_000, Instant::fromDateTime($dt)->epochNanoseconds);
+    }
+
+    public function testFromDateTimeAtEpochZero(): void
+    {
+        $dt = new \DateTimeImmutable('1970-01-01T00:00:00', new \DateTimeZone('UTC'));
+        $i = Instant::fromDateTime($dt);
+
+        static::assertSame(0, $i->epochNanoseconds);
+    }
+
+    public function testFromDateTimePreEpoch(): void
+    {
+        $dt = new \DateTimeImmutable('1969-12-31T23:59:59.998500', new \DateTimeZone('UTC'));
+        $i = Instant::fromDateTime($dt);
+
+        static::assertSame(-1_500_000, $i->epochNanoseconds);
+    }
 }

--- a/tests/Porcelain/InstantTest.php
+++ b/tests/Porcelain/InstantTest.php
@@ -744,4 +744,27 @@ final class InstantTest extends TemporalTestCase
 
         static::assertSame(-1_500_000, $i->epochNanoseconds);
     }
+
+    public function testFromDateTimeFarFutureBeyondInt64Throws(): void
+    {
+        // PHP's int64 nanosecond range covers ~±292 years around 1970. Year 3000
+        // is well past +2262 and would overflow `ts * 10^9` to float before the
+        // `int` return type's TypeError fired. Surface as a range error instead.
+        $dt = new \DateTimeImmutable('3000-01-01T00:00:00', new \DateTimeZone('UTC'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('outside the representable int64 nanosecond range');
+
+        Instant::fromDateTime($dt);
+    }
+
+    public function testFromDateTimeFarPastBeyondInt64Throws(): void
+    {
+        $dt = new \DateTimeImmutable('1500-01-01T00:00:00', new \DateTimeZone('UTC'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('outside the representable int64 nanosecond range');
+
+        Instant::fromDateTime($dt);
+    }
 }

--- a/tests/Porcelain/PlainDateTest.php
+++ b/tests/Porcelain/PlainDateTest.php
@@ -820,4 +820,38 @@ final class PlainDateTest extends TestCase
         static::assertSame(0, $zdt->hour);
         static::assertSame(0, $zdt->minute);
     }
+
+    // -------------------------------------------------------------------------
+    // fromDateTime()
+    // -------------------------------------------------------------------------
+
+    public function testFromDateTimeReadsZoneLocalDate(): void
+    {
+        // 2020-06-15T22:30:00 UTC = 2020-06-16T07:30:00 Asia/Tokyo (next day in Tokyo).
+        // fromDateTime must take the Tokyo-local date, not the UTC one.
+        $dt = new \DateTimeImmutable('2020-06-16T07:30:00', new \DateTimeZone('Asia/Tokyo'));
+        $pd = PlainDate::fromDateTime($dt);
+
+        static::assertSame(2020, $pd->year);
+        static::assertSame(6, $pd->month);
+        static::assertSame(16, $pd->day); // Tokyo's date, not UTC's 15th
+    }
+
+    public function testFromDateTimeDefaultsToIsoCalendar(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T00:00:00', new \DateTimeZone('UTC'));
+        $pd = PlainDate::fromDateTime($dt);
+
+        static::assertSame(Calendar::Iso8601, $pd->calendar);
+    }
+
+    public function testFromDateTimeAcceptsExplicitCalendar(): void
+    {
+        $dt = new \DateTimeImmutable('2024-06-15T00:00:00', new \DateTimeZone('UTC'));
+        $pd = PlainDate::fromDateTime($dt, Calendar::Hebrew);
+
+        static::assertSame(Calendar::Hebrew, $pd->calendar);
+        static::assertNotSame(2024, $pd->year);
+        static::assertSame(2024, $pd->toSpec()->isoYear);
+    }
 }

--- a/tests/Porcelain/PlainDateTimeTest.php
+++ b/tests/Porcelain/PlainDateTimeTest.php
@@ -1102,4 +1102,78 @@ final class PlainDateTimeTest extends TemporalTestCase
         static::assertSame('-04:00', $earlier->offset);
         static::assertSame('-05:00', $later->offset);
     }
+
+    // -------------------------------------------------------------------------
+    // fromDateTime()
+    // -------------------------------------------------------------------------
+
+    public function testFromDateTimeReadsCivilFieldsFromZone(): void
+    {
+        // Same instant, different zones — fromDateTime must take Tokyo's local fields,
+        // not UTC's. 2020-06-15T12:30:45 UTC = 2020-06-15T21:30:45 Asia/Tokyo.
+        $dt = new \DateTimeImmutable('2020-06-15T21:30:45.123456', new \DateTimeZone('Asia/Tokyo'));
+        $pdt = PlainDateTime::fromDateTime($dt);
+
+        static::assertSame(2020, $pdt->year);
+        static::assertSame(6, $pdt->month);
+        static::assertSame(15, $pdt->day);
+        static::assertSame(21, $pdt->hour); // Tokyo, not UTC
+        static::assertSame(30, $pdt->minute);
+        static::assertSame(45, $pdt->second);
+        static::assertSame(123, $pdt->millisecond);
+        static::assertSame(456, $pdt->microsecond);
+        static::assertSame(0, $pdt->nanosecond);
+    }
+
+    public function testFromDateTimeDefaultsToIsoCalendar(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T12:30:45', new \DateTimeZone('UTC'));
+        $pdt = PlainDateTime::fromDateTime($dt);
+
+        static::assertSame(Calendar::Iso8601, $pdt->calendar);
+    }
+
+    public function testFromDateTimeAcceptsExplicitCalendar(): void
+    {
+        $dt = new \DateTimeImmutable('2024-06-15T12:30:45', new \DateTimeZone('UTC'));
+        $pdt = PlainDateTime::fromDateTime($dt, Calendar::Hebrew);
+
+        static::assertSame(Calendar::Hebrew, $pdt->calendar);
+        // The Hebrew projection of the ISO 2024-06-15 date has a non-Gregorian year.
+        static::assertNotSame(2024, $pdt->year);
+        // Spec layer preserves the ISO date used to build it.
+        static::assertSame(2024, $pdt->toSpec()->isoYear);
+        static::assertSame(6, $pdt->toSpec()->isoMonth);
+        static::assertSame(15, $pdt->toSpec()->isoDay);
+    }
+
+    public function testFromDateTimeZeroMicroseconds(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T12:30:45', new \DateTimeZone('UTC'));
+        $pdt = PlainDateTime::fromDateTime($dt);
+
+        static::assertSame(0, $pdt->millisecond);
+        static::assertSame(0, $pdt->microsecond);
+        static::assertSame(0, $pdt->nanosecond);
+    }
+
+    public function testFromDateTimeMaxMicrosecondsSplitsCorrectly(): void
+    {
+        // u=999999 — pins the divisor at exactly 1000 (intdiv(999999, 999)=1001, not 999).
+        $dt = new \DateTimeImmutable('2020-06-15T12:30:45.999999', new \DateTimeZone('UTC'));
+        $pdt = PlainDateTime::fromDateTime($dt);
+
+        static::assertSame(999, $pdt->millisecond);
+        static::assertSame(999, $pdt->microsecond);
+    }
+
+    public function testFromDateTimeMidRangeMicrosecondsSplitCorrectly(): void
+    {
+        // u=500000 — pins divisor at <= 1000 (intdiv(500000, 1001)=499, not 500).
+        $dt = new \DateTimeImmutable('2020-06-15T12:30:45.500000', new \DateTimeZone('UTC'));
+        $pdt = PlainDateTime::fromDateTime($dt);
+
+        static::assertSame(500, $pdt->millisecond);
+        static::assertSame(0, $pdt->microsecond);
+    }
 }

--- a/tests/Porcelain/PlainTimeTest.php
+++ b/tests/Porcelain/PlainTimeTest.php
@@ -627,4 +627,71 @@ final class PlainTimeTest extends TemporalTestCase
         // 7 minutes truncated to nearest 5 = 5
         static::assertSame(5, $d->minutes);
     }
+
+    // -------------------------------------------------------------------------
+    // fromDateTime()
+    // -------------------------------------------------------------------------
+
+    public function testFromDateTimePreservesHmsAndMicroseconds(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T13:45:30.123456', new \DateTimeZone('UTC'));
+        $pt = PlainTime::fromDateTime($dt);
+
+        static::assertSame(13, $pt->hour);
+        static::assertSame(45, $pt->minute);
+        static::assertSame(30, $pt->second);
+        static::assertSame(123, $pt->millisecond);
+        static::assertSame(456, $pt->microsecond);
+        static::assertSame(0, $pt->nanosecond);
+    }
+
+    public function testFromDateTimeUsesZoneLocalTime(): void
+    {
+        // Same instant: 12:30 UTC vs 21:30 Tokyo.
+        $dt = new \DateTimeImmutable('2020-06-15T21:30:00', new \DateTimeZone('Asia/Tokyo'));
+        $pt = PlainTime::fromDateTime($dt);
+
+        static::assertSame(21, $pt->hour); // Tokyo, not UTC
+        static::assertSame(30, $pt->minute);
+    }
+
+    public function testFromDateTimeZeroMicrosecondsZerosAllSubSecondFields(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T13:45:30', new \DateTimeZone('UTC'));
+        $pt = PlainTime::fromDateTime($dt);
+
+        static::assertSame(0, $pt->millisecond);
+        static::assertSame(0, $pt->microsecond);
+        static::assertSame(0, $pt->nanosecond);
+    }
+
+    public function testFromDateTimeMicrosecondOnlyBitSetsBothFields(): void
+    {
+        // 1 microsecond exactly — must produce ms=0, us=1, not ms=1, us=0.
+        $dt = new \DateTimeImmutable('2020-06-15T13:45:30.000001', new \DateTimeZone('UTC'));
+        $pt = PlainTime::fromDateTime($dt);
+
+        static::assertSame(0, $pt->millisecond);
+        static::assertSame(1, $pt->microsecond);
+    }
+
+    public function testFromDateTimeMillisecondOnlyBitSetsCorrectField(): void
+    {
+        // 1 millisecond exactly — must produce ms=1, us=0.
+        $dt = new \DateTimeImmutable('2020-06-15T13:45:30.001000', new \DateTimeZone('UTC'));
+        $pt = PlainTime::fromDateTime($dt);
+
+        static::assertSame(1, $pt->millisecond);
+        static::assertSame(0, $pt->microsecond);
+    }
+
+    public function testFromDateTimeMaxMicrosecondsSplitsCorrectly(): void
+    {
+        // u=999999 — pins the divisor at exactly 1000 (intdiv(999999, 999)=1001, // not 999).
+        $dt = new \DateTimeImmutable('2020-06-15T13:45:30.999999', new \DateTimeZone('UTC'));
+        $pt = PlainTime::fromDateTime($dt);
+
+        static::assertSame(999, $pt->millisecond);
+        static::assertSame(999, $pt->microsecond);
+    }
 }

--- a/tests/Porcelain/ZonedDateTimeTest.php
+++ b/tests/Porcelain/ZonedDateTimeTest.php
@@ -1418,4 +1418,75 @@ final class ZonedDateTimeTest extends TemporalTestCase
         static::assertSame('ce', $zdt->era);
         static::assertSame(2020, $zdt->eraYear);
     }
+
+    // -------------------------------------------------------------------------
+    // fromDateTime() / toDateTime()
+    // -------------------------------------------------------------------------
+
+    public function testFromDateTimeIanaZoneRoundTrip(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T14:30:45.123456', new \DateTimeZone('Europe/Vienna'));
+        $zdt = ZonedDateTime::fromDateTime($dt);
+
+        static::assertSame('Europe/Vienna', $zdt->timeZoneId);
+        static::assertSame(2020, $zdt->year);
+        static::assertSame(6, $zdt->month);
+        static::assertSame(15, $zdt->day);
+        static::assertSame(14, $zdt->hour);
+        static::assertSame(30, $zdt->minute);
+        static::assertSame(45, $zdt->second);
+        static::assertSame(123, $zdt->millisecond);
+        static::assertSame(456, $zdt->microsecond);
+        static::assertSame(0, $zdt->nanosecond);
+
+        $back = $zdt->toDateTime();
+        static::assertSame('Europe/Vienna', $back->format('e'));
+        static::assertSame('2020-06-15T14:30:45.123456+02:00', $back->format('Y-m-d\TH:i:s.uP'));
+    }
+
+    public function testFromDateTimeFixedOffsetZonePreservesOffsetString(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T18:00:45.000123', new \DateTimeZone('+05:30'));
+        $zdt = ZonedDateTime::fromDateTime($dt);
+
+        static::assertSame('+05:30', $zdt->timeZoneId);
+        static::assertSame(18, $zdt->hour);
+
+        $back = $zdt->toDateTime();
+        static::assertSame('+05:30', $back->format('e'));
+        static::assertSame('2020-06-15T18:00:45.000123+05:30', $back->format('Y-m-d\TH:i:s.uP'));
+    }
+
+    public function testFromDateTimeUtc(): void
+    {
+        $dt = new \DateTimeImmutable('2020-06-15T12:30:00', new \DateTimeZone('UTC'));
+        $zdt = ZonedDateTime::fromDateTime($dt);
+
+        static::assertSame('UTC', $zdt->timeZoneId);
+        static::assertSame(1_592_224_200_000_000_000, $zdt->epochNanoseconds);
+
+        $back = $zdt->toDateTime();
+        static::assertSame('UTC', $back->format('e'));
+    }
+
+    public function testFromDateTimeNegativeEpochRoundTrips(): void
+    {
+        // 1.5 ms before epoch in UTC.
+        $dt = new \DateTimeImmutable('1969-12-31T23:59:59.998500', new \DateTimeZone('UTC'));
+        $zdt = ZonedDateTime::fromDateTime($dt);
+
+        static::assertSame(-1_500_000, $zdt->epochNanoseconds);
+
+        $back = $zdt->toDateTime();
+        static::assertSame('1969-12-31T23:59:59.998500+00:00', $back->format('Y-m-d\TH:i:s.uP'));
+    }
+
+    public function testFromDateTimeDropsSubMicrosecondBits(): void
+    {
+        $zdt = new ZonedDateTime(1_592_224_245_123_456_789, 'UTC');
+        $back = ZonedDateTime::fromDateTime($zdt->toDateTime());
+
+        static::assertSame(1_592_224_245_123_456_000, $back->epochNanoseconds);
+        static::assertSame('UTC', $back->timeZoneId);
+    }
 }

--- a/tests/Porcelain/ZonedDateTimeTest.php
+++ b/tests/Porcelain/ZonedDateTimeTest.php
@@ -1489,4 +1489,14 @@ final class ZonedDateTimeTest extends TemporalTestCase
         static::assertSame(1_592_224_245_123_456_000, $back->epochNanoseconds);
         static::assertSame('UTC', $back->timeZoneId);
     }
+
+    public function testFromDateTimeFarFutureBeyondInt64Throws(): void
+    {
+        $dt = new \DateTimeImmutable('3000-01-01T00:00:00', new \DateTimeZone('UTC'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('outside the representable int64 nanosecond range');
+
+        ZonedDateTime::fromDateTime($dt);
+    }
 }


### PR DESCRIPTION
Resolves #19 (closing as won't-fix). Rationale captured in the issue close-out comment.

## What this ships

Native `\DateTimeImmutable` round-trip on the porcelain value types, with no new runtime deps:

| Type | `fromDateTime` | `toDateTime` |
|---|:---:|:---:|
| `Instant` | ✅ | ✅ (optional `\DateTimeZone`, defaults to UTC) |
| `ZonedDateTime` | ✅ | ✅ (preserves IANA names and fixed-offset strings) |
| `PlainDateTime` | ✅ (zone-local civil fields, `Calendar` arg) | — |
| `PlainDate` | ✅ (zone-local Y/M/D, `Calendar` arg) | — |
| `PlainTime` | ✅ (zone-local H/M/S/μs) | — |

`PlainYearMonth` / `PlainMonthDay` are deliberately out of scope; revisit if requested.

The Plain types have no `toDateTime()` because they each lack at least one of {date, time, zone} and there's no honest signature. The asymmetry follows a single principle: *from-direction is universal because narrowing is honest; to-direction lives only on types complete enough to widen without invention*.

## Why this resolves #19

Issue #19 asked whether to ship a clock-injection seam in `Temporal\Now` before 1.0.0 freezes its signatures. This PR takes a different path: `Now` stays TC39-shaped (no seam), and consumers who want testable / non-wall-clock behavior wire their own clock and convert through `ZonedDateTime::fromDateTime(...)` (or `Instant::fromDateTime(...)`), then navigate to the other types via the existing `toInstant()` / `toPlainDate()` / etc. methods.

```php
// Wire any PSR-20 (or any other) clock yourself.
$dt    = $this->clock->now();
$zdt   = ZonedDateTime::fromDateTime($dt);
$inst  = $zdt->toInstant();
$today = $zdt->toPlainDate();
```

Adding a clock seam to `Now` later remains additive (e.g. `?ClockInterface $clock = null` parameter, or sugar like `Now::withClock(...)`) — nothing here precludes that. We just don't pre-commit to the seam at 1.0.0.

## Implementation notes

- Sub-microsecond Temporal bits are zeroed on every conversion (PHP's `\DateTimeImmutable` is microsecond-precision). Documented on every public method.
- `Spec\Internal\DateTimeFields` holds the shared epoch-ns ↔ DateTime arithmetic used by `Instant` and `ZonedDateTime`. Class-level docblock acknowledges it isn't strictly spec-layer machinery — placed in `Internal\` for consistency.
- The Plain types extract calendar fields directly via `$dt->format(...)` rather than going through the helper; the per-type code is too small to abstract.
- Floored division for `toDateTime` correctly handles negative epoch nanoseconds (pre-1970); covered by `testToDateTimeNegativeEpochNanosecondsRoundTripsExactly` and `testToDateTimeNegativeEpochSecondsBoundary`.
- `mago.toml` `too-many-methods` threshold bumped 130 → 140 to accommodate `ZonedDateTimeTest`'s 135 methods after the round-trip additions.

## Per-commit metrics

### `d4296f9a` — Add native DateTimeImmutable interop on porcelain value types

- **Files**: 1 added (`src/Spec/Internal/DateTimeFields.php`), 12 modified.
- **Lines**: +570 / -1.
- **Porcelain tests**: 907 → 937 (+30).
- **Infection**: 100% MSI on the affected files (556 mutants total — 549 killed by tests, 7 caught by static analysis, 0 escaped).
- **Gate**: `composer check` passes (PHPStan level 9, Psalm level 1, Mago lint+analyze, mago format-check, full PHPUnit suite, Infection).
- **Spec-layer surface**: untouched (no `Temporal\Spec\*.php` modifications outside `Internal/`).
- **New runtime deps**: none.

### `05bb802f` — Throw on far-future/past DateTime in epochNanoseconds, fix docblock

- **Files**: 4 modified (`src/PlainDate.php`, `src/Spec/Internal/DateTimeFields.php`, `tests/Porcelain/InstantTest.php`, `tests/Porcelain/ZonedDateTimeTest.php`).
- **Lines**: +56 / -2.
- **Porcelain tests**: 937 → 940 (+3 overflow-guard tests on `Instant::fromDateTime` and `ZonedDateTime::fromDateTime`).
- **Bug fixed**: `($ts * 1_000_000) * 1_000` in `DateTimeFields::epochNanoseconds` silently promoted to float for `\DateTimeInterface` values outside the ~±292-year int64 window (e.g. year 3000), then the `int` return type raised a `TypeError` before any Temporal-aware code could surface a range error. Now bounds-checks at second granularity (threshold `9_223_372_035`, matching `Spec\Instant::from()`) and throws `\InvalidArgumentException` directly with the offending RFC 3339 string in the message.
- **Doc fix**: `PlainDate::fromDateTime()` docblock said "PlainDate is dateless of those"; now reads "PlainDate carries neither" (time-of-day, zone).
- **Gate**: `composer check` passes; 100% MSI on the modified slice.
- **Origin**: addresses both Copilot review comments on this PR.

## Test plan

- [x] `composer check` passes (full gate)
- [x] Round-trip preservation: same `\DateTimeImmutable` in → equivalent `\DateTimeImmutable` out, modulo documented sub-microsecond drop
- [x] Negative epoch (pre-1970) round-trips exactly
- [x] Boundary at exactly epoch zero
- [x] Boundary at exactly -1 second from epoch (catches off-by-one in floor-borrow branch)
- [x] Tokyo / UTC zone-local field reads (Plain types)
- [x] IANA tz preservation (`Europe/Vienna`)
- [x] Fixed-offset zone preservation (`+05:30`)
- [x] Microsecond split: ms=999/μs=999 boundary
- [x] Microsecond split: 1μs / 1ms / 500ms boundaries
- [x] Year 3000 / year 1500 `\DateTimeImmutable` inputs throw with a clear range message (do not crash with `TypeError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)