### PR TITLE
Accept Temporal objects in withCalendar (ToTemporalCalendarIdentifier fast path)

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -65,4 +65,21 @@ enum Calendar: string
 
         return $result;
     }
+
+    /**
+     * Resolves a calendar-like value to a Calendar case.
+     *
+     * Mirrors TC39 ToTemporalCalendarIdentifier's object fast path: a Temporal
+     * date-bearing porcelain value (PlainDate, PlainDateTime, PlainMonthDay,
+     * PlainYearMonth, ZonedDateTime) contributes its own `calendar`; a Calendar
+     * case is returned as-is.
+     */
+    public static function resolve(self|PlainDate|PlainDateTime|PlainMonthDay|PlainYearMonth|ZonedDateTime $calendarLike): self
+    {
+        if ($calendarLike instanceof self) {
+            return $calendarLike;
+        }
+
+        return $calendarLike->calendar;
+    }
 }

--- a/src/PlainDate.php
+++ b/src/PlainDate.php
@@ -194,10 +194,14 @@ final class PlainDate implements \Stringable, \JsonSerializable, HasYearMonthSpe
      * Returns a new PlainDate with a different calendar system.
      *
      * The underlying ISO date remains the same; only the calendar projection changes.
+     *
+     * Accepts a {@see Calendar} case or any Temporal date-bearing value
+     * (PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth, ZonedDateTime),
+     * whose own calendar is used (mirrors TC39 ToTemporalCalendarIdentifier).
      */
-    public function withCalendar(Calendar $calendar): self
+    public function withCalendar(Calendar|PlainDate|PlainDateTime|PlainMonthDay|PlainYearMonth|ZonedDateTime $calendar): self
     {
-        return self::fromSpec($this->spec->withCalendar($calendar->value));
+        return self::fromSpec($this->spec->withCalendar(Calendar::resolve($calendar)->value));
     }
 
     /**

--- a/src/PlainDateTime.php
+++ b/src/PlainDateTime.php
@@ -302,10 +302,14 @@ final class PlainDateTime implements
      * Returns a new PlainDateTime with a different calendar system.
      *
      * The underlying ISO datetime remains the same; only the calendar projection changes.
+     *
+     * Accepts a {@see Calendar} case or any Temporal date-bearing value
+     * (PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth, ZonedDateTime),
+     * whose own calendar is used (mirrors TC39 ToTemporalCalendarIdentifier).
      */
-    public function withCalendar(Calendar $calendar): self
+    public function withCalendar(Calendar|PlainDate|PlainDateTime|PlainMonthDay|PlainYearMonth|ZonedDateTime $calendar): self
     {
-        return self::fromSpec($this->spec->withCalendar($calendar->value));
+        return self::fromSpec($this->spec->withCalendar(Calendar::resolve($calendar)->value));
     }
 
     /**

--- a/src/Spec/PlainDate.php
+++ b/src/Spec/PlainDate.php
@@ -808,14 +808,18 @@ final class PlainDate implements Stringable
     /**
      * Returns a new PlainDate with the specified calendar.
      *
-     * Accepts a bare calendar ID or an ISO date string from which the calendar is extracted.
+     * Per TC39 ToTemporalCalendarIdentifier, $calendar may be:
+     *   - A bare calendar ID, or an ISO date string from which the calendar is extracted.
+     *   - A Temporal date-bearing object (PlainDate, PlainDateTime, PlainMonthDay,
+     *     PlainYearMonth, ZonedDateTime) whose `calendarId` slot is read directly.
      *
+     * @throws TypeError if $calendar is neither a string nor a calendar-bearing Temporal object.
      * @throws RangeError if the calendar is unsupported.
      * @psalm-api
      */
-    public function withCalendar(string $calendar): self
+    public function withCalendar(mixed $calendar): self
     {
-        $calId = CalendarFactory::extractCalendarFromString($calendar);
+        $calId = CalendarFactory::resolveBagCalendar($calendar, 'PlainDate');
         return new self($this->isoYear, $this->isoMonth, $this->isoDay, $calId);
     }
 

--- a/src/Spec/PlainDateTime.php
+++ b/src/Spec/PlainDateTime.php
@@ -1195,12 +1195,17 @@ final class PlainDateTime implements Stringable
     /**
      * Returns a new PlainDateTime with the specified calendar.
      *
+     * Per TC39 ToTemporalCalendarIdentifier, $calendar may be a bare calendar ID,
+     * an ISO date string, or a Temporal date-bearing object whose `calendarId`
+     * slot is read directly.
+     *
+     * @throws TypeError if $calendar is neither a string nor a calendar-bearing Temporal object.
      * @throws RangeError if the calendar is unsupported.
      * @psalm-api
      */
-    public function withCalendar(string $calendar): self
+    public function withCalendar(mixed $calendar): self
     {
-        $calId = CalendarFactory::extractCalendarFromString($calendar);
+        $calId = CalendarFactory::resolveBagCalendar($calendar, 'PlainDateTime');
         return new self(
             $this->isoYear,
             $this->isoMonth,

--- a/src/Spec/ZonedDateTime.php
+++ b/src/Spec/ZonedDateTime.php
@@ -643,14 +643,17 @@ final class ZonedDateTime implements Stringable
     /**
      * Returns a new ZonedDateTime with a different calendar.
      *
-     * Only 'iso8601' is supported (case-insensitive).
+     * Per TC39 ToTemporalCalendarIdentifier, $calendar may be a bare calendar ID,
+     * an ISO date string, or a Temporal date-bearing object whose `calendarId`
+     * slot is read directly.
      *
+     * @throws TypeError if $calendar is neither a string nor a calendar-bearing Temporal object.
      * @throws RangeError if an unsupported calendar is given.
      * @psalm-api
      */
-    public function withCalendar(string $calendar): self
+    public function withCalendar(mixed $calendar): self
     {
-        $calId = CalendarFactory::extractCalendarFromString($calendar);
+        $calId = CalendarFactory::resolveBagCalendar($calendar, 'ZonedDateTime');
         [$epochSec, $subNs] = $this->epochParts();
         return self::fromEpochParts($epochSec, $subNs, $this->timeZoneId, $calId);
     }

--- a/src/ZonedDateTime.php
+++ b/src/ZonedDateTime.php
@@ -558,10 +558,14 @@ final class ZonedDateTime implements
      * Returns a new ZonedDateTime with a different calendar system.
      *
      * The epoch nanoseconds and time zone remain the same; only the calendar projection changes.
+     *
+     * Accepts a {@see Calendar} case or any Temporal date-bearing value
+     * (PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth, ZonedDateTime),
+     * whose own calendar is used (mirrors TC39 ToTemporalCalendarIdentifier).
      */
-    public function withCalendar(Calendar $calendar): self
+    public function withCalendar(Calendar|PlainDate|PlainDateTime|PlainMonthDay|PlainYearMonth|ZonedDateTime $calendar): self
     {
-        return self::fromSpec($this->spec->withCalendar($calendar->value));
+        return self::fromSpec($this->spec->withCalendar(Calendar::resolve($calendar)->value));
     }
 
     /**

--- a/tests/Porcelain/PlainDateTest.php
+++ b/tests/Porcelain/PlainDateTest.php
@@ -618,6 +618,19 @@ final class PlainDateTest extends TestCase
         static::assertNotSame($pd, $result);
     }
 
+    public function testWithCalendarAcceptsTemporalObject(): void
+    {
+        // TC39 ToTemporalCalendarIdentifier fast path: a Temporal date-bearing
+        // value contributes its own calendar.
+        $pd = new PlainDate(2020, 6, 15);
+        $source = new PlainDate(2024, 1, 1, Calendar::Hebrew);
+
+        $result = $pd->withCalendar($source);
+
+        static::assertSame(Calendar::Hebrew, $result->calendar);
+        static::assertSame('2020-06-15', $result->toString(CalendarDisplay::Never));
+    }
+
     // -------------------------------------------------------------------------
     // with() calendar-specific fields
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`withCalendar` deviated from TC39: it typed its parameter as `string` and rejected Temporal objects with a native `TypeError`. The spec's `ToTemporalCalendarIdentifier` has an object fast path — when the argument is a Temporal date-bearing object (`PlainDate`, `PlainDateTime`, `PlainMonthDay`, `PlainYearMonth`, `ZonedDateTime`), it returns that object's `[[Calendar]]`.

This came out of a re-investigation of the test262 "transpiler gap" buckets: it was surfacing as a *transpiler artifact* (`Argument #1 ($calendar) must be of type string, … PlainDate given`) but was a genuine spec bug.

## Changes

- **Spec layer** (`PlainDate`, `PlainDateTime`, `ZonedDateTime`): widen the parameter to `mixed`, resolve via the existing `CalendarFactory::resolveBagCalendar()` (object-with-`calendarId` → read slot; string → parse; non-string non-object → `TypeError`; unknown calendar string → `RangeError`).
- **Porcelain layer**: widen the union to accept the five date-bearing value types alongside `Calendar`, via a new `Calendar::resolve()` helper.
- Added `PlainDateTest::testWithCalendarAcceptsTemporalObject`.

## Per-commit impact

`c729ae46` — unlocks **6** test262 fixtures (`withCalendar/calendar-temporal-object{,-objects}` × {PlainDate, PlainDateTime, ZonedDateTime}). test262 incomplete **417 → 411**, 0 failures. Full `composer check` green: PHPStan 9 / Psalm 1 / Mago clean; Infection **100% covered MSI** (563 mutations, 0 escaped, 0 uncovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)